### PR TITLE
fix(mcp): don't run migrations in mcp server mode

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,6 +14,7 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -44,6 +45,7 @@ jobs:
 
   build-package:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -67,6 +69,7 @@ jobs:
   test-package:
     needs: build-package
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
         with:

--- a/src/kodit/config.py
+++ b/src/kodit/config.py
@@ -47,10 +47,10 @@ class Config(BaseSettings):
         clone_dir.mkdir(parents=True, exist_ok=True)
         return clone_dir
 
-    def get_db(self) -> Database:
+    def get_db(self, *, run_migrations: bool = True) -> Database:
         """Get the database."""
         if self._db is None:
-            self._db = Database(self.db_url)
+            self._db = Database(self.db_url, run_migrations=run_migrations)
         return self._db
 
 

--- a/src/kodit/database.py
+++ b/src/kodit/database.py
@@ -39,10 +39,11 @@ class CommonMixin:
 class Database:
     """Database class for kodit."""
 
-    def __init__(self, db_url: str) -> None:
+    def __init__(self, db_url: str, *, run_migrations: bool = True) -> None:
         """Initialize the database."""
         self.log = structlog.get_logger(__name__)
-        self._configure_database(db_url)
+        if run_migrations:
+            self._run_migrations(db_url)
         db_engine = create_async_engine(db_url, echo=False)
         self.db_session_factory = async_sessionmaker(
             db_engine,
@@ -59,7 +60,7 @@ class Database:
             finally:
                 await session.close()
 
-    def _configure_database(self, db_url: str) -> None:
+    def _run_migrations(self, db_url: str) -> None:
         """Run any pending migrations."""
         # Create Alembic configuration and run migrations
         alembic_cfg = AlembicConfig()

--- a/src/kodit/mcp.py
+++ b/src/kodit/mcp.py
@@ -4,9 +4,10 @@ from pathlib import Path
 from typing import Annotated
 
 import structlog
-from mcp.server.fastmcp import FastMCP
+from fastmcp import FastMCP
 from pydantic import Field
 
+from kodit._version import version
 from kodit.config import get_config
 from kodit.retreival.repository import RetrievalRepository, RetrievalResult
 from kodit.retreival.service import RetrievalRequest, RetrievalService
@@ -113,3 +114,9 @@ def input_fusion(
 def output_fusion(snippets: list[RetrievalResult]) -> str:
     """Fuse the snippets into a single output."""
     return "\n\n".join(f"{snippet.uri}\n{snippet.content}" for snippet in snippets)
+
+
+@mcp.tool()
+async def get_version() -> str:
+    """Get the version of the kodit project."""
+    return version

--- a/src/kodit/mcp.py
+++ b/src/kodit/mcp.py
@@ -7,8 +7,7 @@ import structlog
 from mcp.server.fastmcp import FastMCP
 from pydantic import Field
 
-from kodit.config import config
-from kodit.database import Database
+from kodit.config import get_config
 from kodit.retreival.repository import RetrievalRepository, RetrievalResult
 from kodit.retreival.service import RetrievalRequest, RetrievalService
 
@@ -63,7 +62,10 @@ async def retrieve_relevant_snippets(
         file_contents=related_file_contents,
     )
 
-    db = Database(config.db_url)
+    # Must avoid running migrations because that runs in a separate event loop,
+    # mcp no-likey
+    config = get_config()
+    db = config.get_db(run_migrations=False)
     async with db.get_session() as session:
         log.debug("Creating retrieval repository")
         retrieval_repository = RetrievalRepository(
@@ -72,6 +74,7 @@ async def retrieve_relevant_snippets(
 
         log.debug("Creating retrieval service")
         retrieval_service = RetrievalService(
+            config=config,
             repository=retrieval_repository,
         )
 

--- a/tests/kodit/mcp_test.py
+++ b/tests/kodit/mcp_test.py
@@ -1,109 +1,27 @@
 """Tests for the MCP server implementation."""
 
-from multiprocessing import Process
-
-import httpx
 import pytest
-import uvicorn
-from httpx_retries import Retry, RetryTransport
-from mcp import ClientSession
-from mcp.client.sse import sse_client
+from fastmcp import Client
+from mcp.types import (
+    TextContent,
+)
 
-from kodit.app import app
-
-
-def run_server() -> None:
-    """Run the uvicorn server in a separate process."""
-    config = uvicorn.Config(app, host="127.0.0.1", port=8000, log_level="error")
-    server = uvicorn.Server(config)
-    server.run()
-
-
-async def wait_for_server() -> None:
-    """Wait for the server to start."""
-    retry = Retry(total=5, backoff_factor=0.5)
-    transport = RetryTransport(retry=retry)
-
-    async with httpx.AsyncClient(transport=transport) as client:
-        response = await client.get("http://127.0.0.1:8000/")
-        assert response.status_code == 200
+from kodit.mcp import mcp
 
 
 @pytest.mark.asyncio
 async def test_mcp_client_connection() -> None:
-    """Test connecting to the MCP server using ClientSession."""
-    server_process = None
-    try:
-        # Start the server in a separate process
-        server_process = Process(target=run_server, daemon=True)
-        server_process.start()
+    """Test connecting to the MCP server."""
+    async with Client(mcp) as client:
+        tools = await client.list_tools()
+        assert len(tools) == 2
+        tool = tools[0]
+        assert tool.description is not None
 
-        # Ping the server with requests, wait for it to start
-        await wait_for_server()
-
-        # The sse_client returns read and write streams, not a client object
-        async with (
-            sse_client("http://127.0.0.1:8000/sse/") as (
-                read_stream,
-                write_stream,
-            ),
-            ClientSession(read_stream, write_stream) as session,
-        ):
-            # Initialize the connection
-            await session.initialize()
-
-            # List available tools
-            tools_result = await session.list_tools()
-            # Check that we got a proper tools result with a tools attribute
-            assert hasattr(tools_result, "tools")
-            # Verify we can see the 'retrieve_relevant_snippets' tool
-            tool_names = [tool.name for tool in tools_result.tools]
-            assert "retrieve_relevant_snippets" in tool_names
-    finally:
-        # Due to https://github.com/modelcontextprotocol/python-sdk/issues/514, mcp
-        # doesn't shut down the server when requested. So we have to force kill it.
-        server_process.kill()
-        server_process.join(timeout=1)
-
-
-@pytest.mark.asyncio
-async def test_mcp_code_retrieval() -> None:
-    """Test end-to-end flow of adding code and retrieving it via MCP."""
-    # Can't quite test this properly yet, because the MCP server runs in a separate
-    # process using the user's actual database. So this code is just testing that it
-    # doesn't crash or anything.
-    server_process = None
-    try:
-        # Start the server in a separate process
-        server_process = Process(target=run_server, daemon=True)
-        server_process.start()
-
-        # Wait for server to start
-        await wait_for_server()
-
-        # Connect to MCP server
-        async with (
-            sse_client("http://127.0.0.1:8000/sse/") as (
-                read_stream,
-                write_stream,
-            ),
-            ClientSession(read_stream, write_stream) as mcp_session,
-        ):
-            # Initialize the connection
-            await mcp_session.initialize()
-
-            # Call retrieve_relevant_snippets tool
-            await mcp_session.call_tool(
-                "retrieve_relevant_snippets",
-                {
-                    "user_intent": "I want to find code that prints hello world",
-                    "related_file_paths": [],
-                    "related_file_contents": [],
-                    "keywords": ["hello", "world", "print"],
-                },
-            )
-
-    finally:
-        if server_process:
-            server_process.kill()
-            server_process.join(timeout=1)
+        result = await client.call_tool(
+            "get_version",
+        )
+        assert len(result) == 1
+        content = result[0]
+        assert isinstance(content, TextContent)
+        assert content.text is not None


### PR DESCRIPTION
Still issues with mcp totally taking over the lifecyle, the event loop, everything. On this occasion, the migrations were trying to run in a new event loop, but mcp had already created it. Simplest to just disable it for now.