### PR TITLE
refactor(ux): expose embedding progress and massive speedup

### DIFF
--- a/src/kodit/embedding/embedding_factory.py
+++ b/src/kodit/embedding/embedding_factory.py
@@ -3,6 +3,7 @@
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from kodit.config import AppContext, Endpoint
+from kodit.embedding.embedding_models import EmbeddingType
 from kodit.embedding.embedding_provider.local_embedding_provider import (
     CODE,
     LocalEmbeddingProvider,
@@ -54,9 +55,14 @@ def embedding_factory(
         return VectorChordVectorSearchService(task_name, session, embedding_provider)
     if app_context.default_search.provider == "sqlite":
         log_event("kodit.database", {"provider": "sqlite"})
+        if task_name == "code":
+            embedding_type = EmbeddingType.CODE
+        elif task_name == "text":
+            embedding_type = EmbeddingType.TEXT
         return LocalVectorSearchService(
             embedding_repository=embedding_repository,
             embedding_provider=embedding_provider,
+            embedding_type=embedding_type,
         )
 
     msg = f"Invalid semantic search provider: {app_context.default_search.provider}"

--- a/src/kodit/embedding/embedding_provider/embedding_provider.py
+++ b/src/kodit/embedding/embedding_provider/embedding_provider.py
@@ -1,6 +1,8 @@
 """Embedding provider."""
 
 from abc import ABC, abstractmethod
+from collections.abc import AsyncGenerator
+from dataclasses import dataclass
 
 import structlog
 import tiktoken
@@ -10,11 +12,29 @@ OPENAI_MAX_EMBEDDING_SIZE = 8192
 Vector = list[float]
 
 
+@dataclass
+class EmbeddingRequest:
+    """Embedding request."""
+
+    id: int
+    text: str
+
+
+@dataclass
+class EmbeddingResponse:
+    """Embedding response."""
+
+    id: int
+    embedding: Vector
+
+
 class EmbeddingProvider(ABC):
     """Embedding provider."""
 
     @abstractmethod
-    async def embed(self, data: list[str]) -> list[Vector]:
+    def embed(
+        self, data: list[EmbeddingRequest]
+    ) -> AsyncGenerator[list[EmbeddingResponse], None]:
         """Embed a list of strings.
 
         The embedding provider is responsible for embedding a list of strings into a
@@ -25,13 +45,13 @@ class EmbeddingProvider(ABC):
 
 def split_sub_batches(
     encoding: tiktoken.Encoding,
-    data: list[str],
+    data: list[EmbeddingRequest],
     max_context_window: int = OPENAI_MAX_EMBEDDING_SIZE,
-) -> list[list[str]]:
+) -> list[list[EmbeddingRequest]]:
     """Split a list of strings into smaller sub-batches."""
     log = structlog.get_logger(__name__)
     result = []
-    data_to_process = [s for s in data if s.strip()]  # Filter out empty strings
+    data_to_process = [s for s in data if s.text.strip()]  # Filter out empty strings
 
     while data_to_process:
         next_batch = []
@@ -39,14 +59,16 @@ def split_sub_batches(
 
         while data_to_process:
             next_item = data_to_process[0]
-            item_tokens = len(encoding.encode(next_item, disallowed_special=()))
+            item_tokens = len(encoding.encode(next_item.text, disallowed_special=()))
 
             if item_tokens > max_context_window:
                 # Loop around trying to truncate the snippet until it fits in the max
                 # embedding size
                 while item_tokens > max_context_window:
-                    next_item = next_item[:-1]
-                    item_tokens = len(encoding.encode(next_item, disallowed_special=()))
+                    next_item.text = next_item.text[:-1]
+                    item_tokens = len(
+                        encoding.encode(next_item.text, disallowed_special=())
+                    )
 
                 data_to_process[0] = next_item
 

--- a/src/kodit/embedding/embedding_provider/local_embedding_provider.py
+++ b/src/kodit/embedding/embedding_provider/local_embedding_provider.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import os
-from collections.abc import AsyncGenerator
 from time import time
 from typing import TYPE_CHECKING
 
@@ -17,8 +16,11 @@ from kodit.embedding.embedding_provider.embedding_provider import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
     from sentence_transformers import SentenceTransformer
     from tiktoken import Encoding
+
 
 TINY = "tiny"
 CODE = "code"

--- a/src/kodit/embedding/embedding_provider/local_embedding_provider.py
+++ b/src/kodit/embedding/embedding_provider/local_embedding_provider.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 import os
 from collections.abc import AsyncGenerator
+from time import time
 from typing import TYPE_CHECKING
 
 import structlog
-import tiktoken
 
 from kodit.embedding.embedding_provider.embedding_provider import (
     EmbeddingProvider,
@@ -18,6 +18,7 @@ from kodit.embedding.embedding_provider.embedding_provider import (
 
 if TYPE_CHECKING:
     from sentence_transformers import SentenceTransformer
+    from tiktoken import Encoding
 
 TINY = "tiny"
 CODE = "code"
@@ -37,8 +38,22 @@ class LocalEmbeddingProvider(EmbeddingProvider):
         """Initialize the local embedder."""
         self.log = structlog.get_logger(__name__)
         self.model_name = COMMON_EMBEDDING_MODELS.get(model_name, model_name)
+        self.encoding_name = "text-embedding-3-small"
         self.embedding_model = None
-        self.encoding = tiktoken.encoding_for_model("text-embedding-3-small")
+        self.encoding = None
+
+    def _encoding(self) -> Encoding:
+        if self.encoding is None:
+            from tiktoken import encoding_for_model
+
+            start_time = time()
+            self.encoding = encoding_for_model(self.encoding_name)
+            self.log.debug(
+                "Encoding loaded",
+                model_name=self.encoding_name,
+                duration=time() - start_time,
+            )
+        return self.encoding
 
     def _model(self) -> SentenceTransformer:
         """Get the embedding model."""
@@ -46,9 +61,15 @@ class LocalEmbeddingProvider(EmbeddingProvider):
             os.environ["TOKENIZERS_PARALLELISM"] = "false"  # Avoid warnings
             from sentence_transformers import SentenceTransformer
 
+            start_time = time()
             self.embedding_model = SentenceTransformer(
                 self.model_name,
                 trust_remote_code=True,
+            )
+            self.log.debug(
+                "Model loaded",
+                model_name=self.model_name,
+                duration=time() - start_time,
             )
         return self.embedding_model
 
@@ -58,7 +79,7 @@ class LocalEmbeddingProvider(EmbeddingProvider):
         """Embed a list of strings."""
         model = self._model()
 
-        batched_data = split_sub_batches(self.encoding, data)
+        batched_data = split_sub_batches(self._encoding(), data)
 
         for batch in batched_data:
             embeddings = model.encode(

--- a/src/kodit/embedding/local_vector_search_service.py
+++ b/src/kodit/embedding/local_vector_search_service.py
@@ -6,7 +6,10 @@ import structlog
 import tiktoken
 
 from kodit.embedding.embedding_models import Embedding, EmbeddingType
-from kodit.embedding.embedding_provider.embedding_provider import EmbeddingProvider
+from kodit.embedding.embedding_provider.embedding_provider import (
+    EmbeddingProvider,
+    EmbeddingRequest,
+)
 from kodit.embedding.embedding_repository import EmbeddingRepository
 from kodit.embedding.vector_search_service import (
     IndexResult,
@@ -38,42 +41,21 @@ class LocalVectorSearchService(VectorSearchService):
             self.log.warning("Embedding data is empty, skipping embedding")
             return
 
-        # Prepare requests for the embedding provider.
-        from kodit.embedding.embedding_provider.embedding_provider import (
-            EmbeddingRequest,
-        )
+        requests = [EmbeddingRequest(id=doc.snippet_id, text=doc.text) for doc in data]
 
-        requests = [
-            EmbeddingRequest(id=idx, text=item.text) for idx, item in enumerate(data)
-        ]
-
-        # Collect embeddings from the async generator while preserving order.
-        embeddings_map: dict[int, list[float]] = {}
         async for batch in self.embedding_provider.embed(requests):
-            for resp in batch:
-                embeddings_map[resp.id] = [float(v) for v in resp.embedding]
-
-        # Persist embeddings following the original data order.
-        for idx, item in enumerate(data):
-            embedding_vec = embeddings_map.get(idx)
-            if embedding_vec is None:
-                # Skip if the provider returned no embedding (e.g., empty text)
-                continue
-            await self.embedding_repository.create_embedding(
-                Embedding(
-                    snippet_id=item.snippet_id,
-                    embedding=embedding_vec,
-                    type=EmbeddingType.CODE,
+            for result in batch:
+                await self.embedding_repository.create_embedding(
+                    Embedding(
+                        snippet_id=result.id,
+                        embedding=result.embedding,
+                        type=EmbeddingType.CODE,
+                    )
                 )
-            )
-            yield [IndexResult(snippet_id=item.snippet_id)]
+                yield [IndexResult(snippet_id=result.id)]
 
     async def retrieve(self, query: str, top_k: int = 10) -> list[VectorSearchResponse]:
         """Query the embedding model."""
-        from kodit.embedding.embedding_provider.embedding_provider import (
-            EmbeddingRequest,
-        )
-
         # Build a single-item request and collect its embedding.
         req = EmbeddingRequest(id=0, text=query)
         embedding_vec: list[float] | None = None

--- a/src/kodit/embedding/local_vector_search_service.py
+++ b/src/kodit/embedding/local_vector_search_service.py
@@ -26,12 +26,14 @@ class LocalVectorSearchService(VectorSearchService):
         self,
         embedding_repository: EmbeddingRepository,
         embedding_provider: EmbeddingProvider,
+        embedding_type: EmbeddingType = EmbeddingType.CODE,
     ) -> None:
         """Initialize the local embedder."""
         self.log = structlog.get_logger(__name__)
         self.embedding_repository = embedding_repository
         self.embedding_provider = embedding_provider
         self.encoding = tiktoken.encoding_for_model("text-embedding-3-small")
+        self.embedding_type = embedding_type
 
     async def index(
         self, data: list[VectorSearchRequest]
@@ -48,7 +50,7 @@ class LocalVectorSearchService(VectorSearchService):
                     Embedding(
                         snippet_id=result.id,
                         embedding=result.embedding,
-                        type=EmbeddingType.CODE,
+                        type=self.embedding_type,
                     )
                 )
                 yield [IndexResult(snippet_id=result.id)]
@@ -67,7 +69,7 @@ class LocalVectorSearchService(VectorSearchService):
             return []
 
         results = await self.embedding_repository.list_semantic_results(
-            EmbeddingType.CODE, embedding_vec, top_k
+            self.embedding_type, embedding_vec, top_k
         )
         return [
             VectorSearchResponse(snippet_id, score) for snippet_id, score in results

--- a/src/kodit/embedding/local_vector_search_service.py
+++ b/src/kodit/embedding/local_vector_search_service.py
@@ -38,7 +38,6 @@ class LocalVectorSearchService(VectorSearchService):
     ) -> AsyncGenerator[list[IndexResult], None]:
         """Embed a list of documents."""
         if not data or len(data) == 0:
-            self.log.warning("Embedding data is empty, skipping embedding")
             return
 
         requests = [EmbeddingRequest(id=doc.snippet_id, text=doc.text) for doc in data]
@@ -73,3 +72,14 @@ class LocalVectorSearchService(VectorSearchService):
         return [
             VectorSearchResponse(snippet_id, score) for snippet_id, score in results
         ]
+
+    async def has_embedding(
+        self, snippet_id: int, embedding_type: EmbeddingType
+    ) -> bool:
+        """Check if a snippet has an embedding."""
+        return (
+            await self.embedding_repository.get_embedding_by_snippet_id_and_type(
+                snippet_id, embedding_type
+            )
+            is not None
+        )

--- a/src/kodit/embedding/vector_search_service.py
+++ b/src/kodit/embedding/vector_search_service.py
@@ -1,6 +1,7 @@
 """Embedding service."""
 
 from abc import ABC, abstractmethod
+from collections.abc import AsyncGenerator
 from typing import NamedTuple
 
 
@@ -18,11 +19,19 @@ class VectorSearchRequest(NamedTuple):
     text: str
 
 
+class IndexResult(NamedTuple):
+    """Result of indexing."""
+
+    snippet_id: int
+
+
 class VectorSearchService(ABC):
     """Semantic search service interface."""
 
     @abstractmethod
-    async def index(self, data: list[VectorSearchRequest]) -> None:
+    def index(
+        self, data: list[VectorSearchRequest]
+    ) -> AsyncGenerator[list[IndexResult], None]:
         """Embed a list of documents.
 
         The embedding service accepts a massive list of id,strings to embed. Behind the

--- a/src/kodit/embedding/vector_search_service.py
+++ b/src/kodit/embedding/vector_search_service.py
@@ -4,6 +4,8 @@ from abc import ABC, abstractmethod
 from collections.abc import AsyncGenerator
 from typing import NamedTuple
 
+from kodit.embedding.embedding_models import EmbeddingType
+
 
 class VectorSearchResponse(NamedTuple):
     """Embedding result."""
@@ -45,3 +47,9 @@ class VectorSearchService(ABC):
     @abstractmethod
     async def retrieve(self, query: str, top_k: int = 10) -> list[VectorSearchResponse]:
         """Query the embedding model."""
+
+    @abstractmethod
+    async def has_embedding(
+        self, snippet_id: int, embedding_type: EmbeddingType
+    ) -> bool:
+        """Check if a snippet has an embedding."""

--- a/src/kodit/enrichment/enrichment_provider/enrichment_provider.py
+++ b/src/kodit/enrichment/enrichment_provider/enrichment_provider.py
@@ -1,6 +1,8 @@
 """Enrichment provider."""
 
 from abc import ABC, abstractmethod
+from collections.abc import AsyncGenerator
+from dataclasses import dataclass
 
 ENRICHMENT_SYSTEM_PROMPT = """
 You are a professional software developer. You will be given a snippet of code.
@@ -8,9 +10,27 @@ Please provide a concise explanation of the code.
 """
 
 
+@dataclass
+class EnrichmentRequest:
+    """Enrichment request."""
+
+    snippet_id: int
+    text: str
+
+
+@dataclass
+class EnrichmentResponse:
+    """Enrichment response."""
+
+    snippet_id: int
+    text: str
+
+
 class EnrichmentProvider(ABC):
     """Enrichment provider."""
 
     @abstractmethod
-    async def enrich(self, data: list[str]) -> list[str]:
+    def enrich(
+        self, data: list[EnrichmentRequest]
+    ) -> AsyncGenerator[EnrichmentResponse, None]:
         """Enrich a list of strings."""

--- a/src/kodit/enrichment/enrichment_provider/local_enrichment_provider.py
+++ b/src/kodit/enrichment/enrichment_provider/local_enrichment_provider.py
@@ -93,7 +93,7 @@ class LocalEnrichmentProvider(EnrichmentProvider):
                 **model_inputs, max_new_tokens=self.context_window
             )
             content = self.tokenizer.decode(
-                generated_ids, skip_special_tokens=True
+                generated_ids.tolist()[0], skip_special_tokens=True
             ).strip("\n")
             yield EnrichmentResponse(
                 snippet_id=prompt.id,

--- a/src/kodit/enrichment/enrichment_provider/local_enrichment_provider.py
+++ b/src/kodit/enrichment/enrichment_provider/local_enrichment_provider.py
@@ -1,15 +1,19 @@
 """Local embedding service."""
 
 import os
+from collections.abc import AsyncGenerator
 
 import structlog
 import tiktoken
-from tqdm import tqdm
 
-from kodit.embedding.embedding_provider.embedding_provider import split_sub_batches
+from kodit.embedding.embedding_provider.embedding_provider import (
+    EmbeddingRequest,
+)
 from kodit.enrichment.enrichment_provider.enrichment_provider import (
     ENRICHMENT_SYSTEM_PROMPT,
     EnrichmentProvider,
+    EnrichmentRequest,
+    EnrichmentResponse,
 )
 
 DEFAULT_ENRICHMENT_MODEL = "Qwen/Qwen3-0.6B"
@@ -32,11 +36,13 @@ class LocalEnrichmentProvider(EnrichmentProvider):
         self.tokenizer = None
         self.encoding = tiktoken.encoding_for_model("text-embedding-3-small")
 
-    async def enrich(self, data: list[str]) -> list[str]:
+    async def enrich(
+        self, data: list[EnrichmentRequest]
+    ) -> AsyncGenerator[EnrichmentResponse, None]:
         """Enrich a list of strings."""
         if not data or len(data) == 0:
             self.log.warning("Data is empty, skipping enrichment")
-            return []
+            return
 
         from transformers.models.auto.modeling_auto import (
             AutoModelForCausalLM,
@@ -57,27 +63,28 @@ class LocalEnrichmentProvider(EnrichmentProvider):
             )
 
         # Prepare prompts
-        prompts = [
-            self.tokenizer.apply_chat_template(
-                [
-                    {"role": "system", "content": ENRICHMENT_SYSTEM_PROMPT},
-                    {"role": "user", "content": snippet},
-                ],
-                tokenize=False,
-                add_generation_prompt=True,
-                enable_thinking=False,
+        prompts: list[EmbeddingRequest] = [
+            EmbeddingRequest(
+                id=snippet.snippet_id,
+                text=self.tokenizer.apply_chat_template(
+                    [
+                        {"role": "system", "content": ENRICHMENT_SYSTEM_PROMPT},
+                        {"role": "user", "content": snippet.text},
+                    ],
+                    tokenize=False,
+                    add_generation_prompt=True,
+                    enable_thinking=False,
+                ),
             )
             for snippet in data
         ]
 
-        # Batch prompts using split_sub_batches
-        batched_prompts = split_sub_batches(
-            self.encoding, prompts, max_context_window=self.context_window
-        )
-        results = []
-        for batch in tqdm(batched_prompts, leave=False, total=len(batched_prompts)):
+        for prompt in prompts:
             model_inputs = self.tokenizer(
-                batch, return_tensors="pt", padding=True, truncation=True
+                prompt.text,
+                return_tensors="pt",
+                padding=True,
+                truncation=True,
             ).to(self.model.device)
             generated_ids = self.model.generate(
                 **model_inputs, max_new_tokens=self.context_window
@@ -88,5 +95,7 @@ class LocalEnrichmentProvider(EnrichmentProvider):
                 content = self.tokenizer.decode(
                     output_ids, skip_special_tokens=True
                 ).strip("\n")
-                results.append(content)
-        return results
+                yield EnrichmentResponse(
+                    snippet_id=prompt.id,
+                    text=content,
+                )

--- a/src/kodit/enrichment/enrichment_provider/local_enrichment_provider.py
+++ b/src/kodit/enrichment/enrichment_provider/local_enrichment_provider.py
@@ -92,9 +92,11 @@ class LocalEnrichmentProvider(EnrichmentProvider):
             generated_ids = self.model.generate(
                 **model_inputs, max_new_tokens=self.context_window
             )
-            content = self.tokenizer.decode(
-                generated_ids.tolist()[0], skip_special_tokens=True
-            ).strip("\n")
+            input_ids = model_inputs["input_ids"][0]
+            output_ids = generated_ids[0][len(input_ids) :].tolist()
+            content = self.tokenizer.decode(output_ids, skip_special_tokens=True).strip(
+                "\n"
+            )
             yield EnrichmentResponse(
                 snippet_id=prompt.id,
                 text=content,

--- a/src/kodit/enrichment/enrichment_provider/openai_enrichment_provider.py
+++ b/src/kodit/enrichment/enrichment_provider/openai_enrichment_provider.py
@@ -1,15 +1,17 @@
 """OpenAI embedding service."""
 
 import asyncio
+from collections.abc import AsyncGenerator
 
 import structlog
 import tiktoken
 from openai import AsyncOpenAI
-from tqdm import tqdm
 
 from kodit.enrichment.enrichment_provider.enrichment_provider import (
     ENRICHMENT_SYSTEM_PROMPT,
     EnrichmentProvider,
+    EnrichmentRequest,
+    EnrichmentResponse,
 )
 
 OPENAI_NUM_PARALLEL_TASKS = 10
@@ -29,25 +31,24 @@ class OpenAIEnrichmentProvider(EnrichmentProvider):
         self.model_name = model_name
         self.encoding = tiktoken.encoding_for_model("gpt-4o-mini")  # Approximation
 
-    async def enrich(self, data: list[str]) -> list[str]:
+    async def enrich(
+        self, data: list[EnrichmentRequest]
+    ) -> AsyncGenerator[EnrichmentResponse, None]:
         """Enrich a list of documents."""
         if not data or len(data) == 0:
             self.log.warning("Data is empty, skipping enrichment")
-            return []
+            return
 
         # Process batches in parallel with a semaphore to limit concurrent requests
         sem = asyncio.Semaphore(OPENAI_NUM_PARALLEL_TASKS)
 
-        # Create a list of tuples with a temporary id for each snippet
-        # We need to do this so that we can return the results in the same order as the
-        # input data
-        input_data = [(i, snippet) for i, snippet in enumerate(data)]
-
-        async def process_data(data: tuple[int, str]) -> tuple[int, str]:
-            snippet_id, snippet = data
-            if not snippet:
-                return snippet_id, ""
+        async def process_data(data: EnrichmentRequest) -> EnrichmentResponse:
             async with sem:
+                if not data.text:
+                    return EnrichmentResponse(
+                        snippet_id=data.snippet_id,
+                        text="",
+                    )
                 try:
                     response = await self.openai_client.chat.completions.create(
                         model=self.model_name,
@@ -56,26 +57,23 @@ class OpenAIEnrichmentProvider(EnrichmentProvider):
                                 "role": "system",
                                 "content": ENRICHMENT_SYSTEM_PROMPT,
                             },
-                            {"role": "user", "content": snippet},
+                            {"role": "user", "content": data.text},
                         ],
                     )
-                    return snippet_id, response.choices[0].message.content or ""
+                    return EnrichmentResponse(
+                        snippet_id=data.snippet_id,
+                        text=response.choices[0].message.content or "",
+                    )
                 except Exception as e:
                     self.log.exception("Error enriching data", error=str(e))
-                    return snippet_id, ""
+                    return EnrichmentResponse(
+                        snippet_id=data.snippet_id,
+                        text="",
+                    )
 
         # Create tasks for all data
-        tasks = [process_data(snippet) for snippet in input_data]
+        tasks = [process_data(snippet) for snippet in data]
 
         # Process all data and yield results as they complete
-        results: list[tuple[int, str]] = []
-        for task in tqdm(
-            asyncio.as_completed(tasks),
-            total=len(tasks),
-            leave=False,
-        ):
-            result = await task
-            results.append(result)
-
-        # Output in the same order as the input data
-        return [result for _, result in sorted(results, key=lambda x: x[0])]
+        for task in asyncio.as_completed(tasks):
+            yield await task

--- a/src/kodit/enrichment/enrichment_service.py
+++ b/src/kodit/enrichment/enrichment_service.py
@@ -1,24 +1,34 @@
 """Enrichment service."""
 
 from abc import ABC, abstractmethod
+from collections.abc import AsyncGenerator
 
-from kodit.enrichment.enrichment_provider.enrichment_provider import EnrichmentProvider
+from kodit.enrichment.enrichment_provider.enrichment_provider import (
+    EnrichmentProvider,
+    EnrichmentRequest,
+    EnrichmentResponse,
+)
 
 
 class EnrichmentService(ABC):
     """Enrichment service."""
 
     @abstractmethod
-    async def enrich(self, data: list[str]) -> list[str]:
+    def enrich(
+        self, data: list[EnrichmentRequest]
+    ) -> AsyncGenerator[EnrichmentResponse, None]:
         """Enrich a list of strings."""
 
 
 class NullEnrichmentService(EnrichmentService):
     """Null enrichment service."""
 
-    async def enrich(self, data: list[str]) -> list[str]:
+    async def enrich(
+        self, data: list[EnrichmentRequest]
+    ) -> AsyncGenerator[EnrichmentResponse, None]:
         """Enrich a list of strings."""
-        return [""] * len(data)
+        for request in data:
+            yield EnrichmentResponse(snippet_id=request.snippet_id, text="")
 
 
 class LLMEnrichmentService(EnrichmentService):
@@ -28,6 +38,8 @@ class LLMEnrichmentService(EnrichmentService):
         """Initialize the enrichment service."""
         self.enrichment_provider = enrichment_provider
 
-    async def enrich(self, data: list[str]) -> list[str]:
-        """Enrich a list of strings."""
-        return await self.enrichment_provider.enrich(data)
+    def enrich(
+        self, data: list[EnrichmentRequest]
+    ) -> AsyncGenerator[EnrichmentResponse, None]:
+        """Enrich a list of snippets."""
+        return self.enrichment_provider.enrich(data)

--- a/src/kodit/indexing/indexing_service.py
+++ b/src/kodit/indexing/indexing_service.py
@@ -22,6 +22,7 @@ from kodit.embedding.vector_search_service import (
     VectorSearchRequest,
     VectorSearchService,
 )
+from kodit.enrichment.enrichment_provider.enrichment_provider import EnrichmentRequest
 from kodit.enrichment.enrichment_service import EnrichmentService
 from kodit.indexing.fusion import FusionRequest, reciprocal_rank_fusion
 from kodit.indexing.indexing_models import Snippet
@@ -210,31 +211,32 @@ class IndexService:
                 pbar.update(len(result))
 
         self.log.info("Enriching snippets", num_snippets=len(snippets))
-        enriched_contents = await self.enrichment_service.enrich(
-            [snippet.content for snippet in snippets]
-        )
+        enriched_contents = []
+        with tqdm(total=len(snippets), leave=False) as pbar:
+            async for result in self.enrichment_service.enrich(
+                [
+                    EnrichmentRequest(snippet_id=snippet.id, text=snippet.content)
+                    for snippet in snippets
+                ]
+            ):
+                snippet = next(s for s in snippets if s.id == result.snippet_id)
+                if snippet:
+                    snippet.content = (
+                        result.text + "\n\n```\n" + snippet.content + "\n```"
+                    )
+                    await self.repository.add_snippet(snippet)
+                    enriched_contents.append(result)
+                pbar.update(1)
 
         self.log.info("Creating semantic text index")
         with tqdm(total=len(snippets), leave=False) as pbar:
             async for result in self.text_search_service.index(
                 [
-                    VectorSearchRequest(snippet.id, enriched_content)
-                    for snippet, enriched_content in zip(
-                        snippets, enriched_contents, strict=True
-                    )
+                    VectorSearchRequest(snippet.id, snippet.content)
+                    for snippet in snippets
                 ]
             ):
                 pbar.update(len(result))
-
-        # Add the enriched text back to the snippets and write to the database
-        with Spinner():
-            for snippet, enriched_content in zip(
-                snippets, enriched_contents, strict=True
-            ):
-                snippet.content = (
-                    enriched_content + "\n\n```\n" + snippet.content + "\n```"
-                )
-                await self.repository.add_snippet(snippet)
 
         # Update index timestamp
         await self.repository.update_index_timestamp(index)

--- a/tests/kodit/embedding/embedding_provider/local_embedding_provider_test.py
+++ b/tests/kodit/embedding/embedding_provider/local_embedding_provider_test.py
@@ -118,6 +118,17 @@ async def test_split_sub_batches(provider):
     )
 
 
+@pytest.mark.asyncio
+async def test_split_sub_batches_performance_test(provider):
+    """Test that the embedding provider batches the text correctly."""
+    encoding = tiktoken.encoding_for_model("text-embedding-3-small")
+    requests = [
+        EmbeddingRequest(id=i, text="This is a test sentence. <|endoftext|>" * 1000)
+        for i in range(1)
+    ]
+    split_sub_batches(encoding, requests)
+
+
 # Utility to gather embeddings from the async generator returned by the provider.
 async def collect_embeddings(provider, requests: list[EmbeddingRequest]):
     """Collect embeddings from the provider while preserving request order."""

--- a/tests/kodit/embedding/embedding_provider/local_embedding_provider_test.py
+++ b/tests/kodit/embedding/embedding_provider/local_embedding_provider_test.py
@@ -4,7 +4,9 @@ import pytest
 from sentence_transformers import SentenceTransformer
 import tiktoken
 
+# Helper imports
 from kodit.embedding.embedding_provider.embedding_provider import (
+    EmbeddingRequest,
     split_sub_batches,
 )
 from kodit.embedding.embedding_provider.local_embedding_provider import (
@@ -32,7 +34,7 @@ async def test_model_lazy_loading(provider):
 async def test_embed_single_text(provider):
     """Test embedding a single text."""
     text = "This is a test sentence."
-    embeddings = await provider.embed([text])
+    embeddings = await collect_embeddings(provider, [EmbeddingRequest(id=0, text=text)])
 
     assert len(embeddings) == 1
     assert isinstance(embeddings[0], list)
@@ -43,7 +45,9 @@ async def test_embed_single_text(provider):
 async def test_embed_multiple_texts(provider):
     """Test embedding multiple texts."""
     texts = ["First test sentence.", "Second test sentence.", "Third test sentence."]
-    embeddings = await provider.embed(texts)
+    embeddings = await collect_embeddings(
+        provider, [EmbeddingRequest(id=i, text=text) for i, text in enumerate(texts)]
+    )
 
     assert len(embeddings) == 3
     assert all(isinstance(emb, list) for emb in embeddings)
@@ -53,7 +57,7 @@ async def test_embed_multiple_texts(provider):
 @pytest.mark.asyncio
 async def test_embed_empty_list(provider):
     """Test embedding an empty list."""
-    embeddings = await provider.embed([])
+    embeddings = await collect_embeddings(provider, [EmbeddingRequest(id=0, text="")])
     assert len(embeddings) == 0
 
 
@@ -62,7 +66,9 @@ async def test_embed_large_text(provider):
     """Test embedding a large text that might need batching."""
     # Create a large text that exceeds typical token limits
     large_text = "This is a test sentence. " * 1000
-    embeddings = await provider.embed([large_text])
+    embeddings = await collect_embeddings(
+        provider, [EmbeddingRequest(id=0, text=large_text)]
+    )
 
     assert len(embeddings) == 1
     assert isinstance(embeddings[0], list)
@@ -78,7 +84,9 @@ async def test_embed_special_characters(provider):
         "Special chars: @#$%^&*()",
         "Unicode: 你好世界",
     ]
-    embeddings = await provider.embed(texts)
+    embeddings = await collect_embeddings(
+        provider, [EmbeddingRequest(id=i, text=text) for i, text in enumerate(texts)]
+    )
 
     assert len(embeddings) == 4
     assert all(isinstance(emb, list) for emb in embeddings)
@@ -89,12 +97,14 @@ async def test_embed_special_characters(provider):
 async def test_embed_consistency(provider):
     """Test that embedding the same text multiple times produces consistent results."""
     text = "This is a test sentence."
-    embeddings1 = await provider.embed([text])
-    embeddings2 = await provider.embed([text])
+    response1 = await anext(provider.embed([EmbeddingRequest(id=0, text=text)]))
+    response2 = await anext(provider.embed([EmbeddingRequest(id=0, text=text)]))
 
-    assert len(embeddings1) == len(embeddings2)
-    assert len(embeddings1[0]) == len(embeddings2[0])
-    assert all(abs(x - y) < 1e-6 for x, y in zip(embeddings1[0], embeddings2[0]))
+    assert len(response1) == len(response2)
+    # Extract embeddings and compare
+    embeddings1 = response1[0].embedding
+    embeddings2 = response2[0].embedding
+    assert all(abs(x - y) < 1e-6 for x, y in zip(embeddings1, embeddings2))
 
 
 @pytest.mark.asyncio
@@ -102,4 +112,20 @@ async def test_split_sub_batches(provider):
     """Test that the embedding provider batches the text correctly."""
     encoding = tiktoken.encoding_for_model("text-embedding-3-small")
     # Should not crash
-    split_sub_batches(encoding, ["This is a test sentence. <|endoftext|>"])
+    split_sub_batches(
+        encoding,
+        [EmbeddingRequest(id=0, text="This is a test sentence. <|endoftext|>")],
+    )
+
+
+# Utility to gather embeddings from the async generator returned by the provider.
+async def collect_embeddings(provider, requests: list[EmbeddingRequest]):
+    """Collect embeddings from the provider while preserving request order."""
+    # Map id -> embedding
+    embeddings_map: dict[int, list[float]] = {}
+    async for batch in provider.embed(requests):
+        for resp in batch:
+            embeddings_map[resp.id] = resp.embedding
+
+    # Return in order of request ids
+    return [embeddings_map[idx] for idx in sorted(embeddings_map.keys())]

--- a/tests/kodit/embedding/local_vector_search_service_test.py
+++ b/tests/kodit/embedding/local_vector_search_service_test.py
@@ -95,7 +95,7 @@ async def test_retrieve_documents(
         VectorSearchRequest(snippet_id=snippet2.id, text=snippet2.content),
         VectorSearchRequest(snippet_id=snippet3.id, text=snippet3.content),
     ]
-    await vector_search_service.index(test_data)
+    [gen async for gen in vector_search_service.index(test_data)]
 
     results = await vector_search_service.retrieve(
         "python programming language", top_k=2
@@ -142,7 +142,7 @@ async def test_retrieve_with_custom_top_k(
         VectorSearchRequest(snippet_id=snippet2.id, text=snippet2.content),
         VectorSearchRequest(snippet_id=snippet3.id, text=snippet3.content),
     ]
-    await vector_search_service.index(test_data)
+    await anext(vector_search_service.index(test_data))
 
     results = await vector_search_service.retrieve("test", top_k=1)
 

--- a/tests/kodit/embedding/local_vector_search_service_test.py
+++ b/tests/kodit/embedding/local_vector_search_service_test.py
@@ -10,7 +10,7 @@ from kodit.embedding.vector_search_service import (
     VectorSearchRequest,
     VectorSearchResponse,
 )
-from kodit.embedding.embedding_models import EmbeddingType
+from kodit.embedding.embedding_models import Embedding, EmbeddingType
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from kodit.indexing.indexing_models import Index, Snippet
@@ -147,3 +147,32 @@ async def test_retrieve_with_custom_top_k(
     results = await vector_search_service.retrieve("test", top_k=1)
 
     assert len(results) == 1
+
+
+@pytest.mark.asyncio
+async def test_has_embedding(
+    vector_search_service: LocalVectorSearchService,
+    session: AsyncSession,
+):
+    index_id, file_id = await create_dummy_db_file(session)
+
+    snippet1 = Snippet(
+        index_id=index_id, file_id=file_id, content="python programming language"
+    )
+
+    session.add(snippet1)
+    await session.commit()
+
+    assert not await vector_search_service.has_embedding(
+        snippet1.id, EmbeddingType.CODE
+    )
+
+    embedding = Embedding(
+        snippet_id=snippet1.id,
+        type=EmbeddingType.CODE,
+        embedding=[0.1, 0.2, 0.3],
+    )
+    session.add(embedding)
+    await session.commit()
+
+    assert await vector_search_service.has_embedding(snippet1.id, EmbeddingType.CODE)

--- a/tests/kodit/embedding/vectorchord_vector_search_service_test.py
+++ b/tests/kodit/embedding/vectorchord_vector_search_service_test.py
@@ -151,7 +151,7 @@ def embedding_provider():
 @pytest.fixture
 def vector_search_service(
     vectorchord_session: AsyncSession, embedding_provider: EmbeddingProvider
-):
+) -> VectorChordVectorSearchService:
     return VectorChordVectorSearchService(
         task_name="text",
         session=vectorchord_session,
@@ -161,7 +161,7 @@ def vector_search_service(
 
 @pytest.mark.asyncio
 async def test_retrieve_documents(
-    vector_search_service: LocalVectorSearchService, session: AsyncSession
+    vector_search_service: VectorChordVectorSearchService, session: AsyncSession
 ):
     index_id, file_id = await create_dummy_db_file(session)
 
@@ -184,7 +184,7 @@ async def test_retrieve_documents(
         VectorSearchRequest(snippet_id=snippet2.id, text=snippet2.content),
         VectorSearchRequest(snippet_id=snippet3.id, text=snippet3.content),
     ]
-    await vector_search_service.index(test_data)
+    [gen async for gen in vector_search_service.index(test_data)]
 
     results = await vector_search_service.retrieve(
         "python programming language", top_k=2
@@ -231,7 +231,7 @@ async def test_retrieve_with_custom_top_k(
         VectorSearchRequest(snippet_id=snippet2.id, text=snippet2.content),
         VectorSearchRequest(snippet_id=snippet3.id, text=snippet3.content),
     ]
-    await vector_search_service.index(test_data)
+    [gen async for gen in vector_search_service.index(test_data)]
 
     results = await vector_search_service.retrieve("test", top_k=1)
 

--- a/tests/kodit/embedding/vectorchord_vector_search_service_test.py
+++ b/tests/kodit/embedding/vectorchord_vector_search_service_test.py
@@ -25,7 +25,7 @@ from kodit.embedding.vector_search_service import (
     VectorSearchRequest,
     VectorSearchResponse,
 )
-from kodit.embedding.embedding_models import EmbeddingType
+from kodit.embedding.embedding_models import Embedding, EmbeddingType
 from sqlalchemy.ext.asyncio import AsyncSession
 from kodit.indexing.indexing_models import Index, Snippet
 from kodit.source.source_models import File, Source
@@ -236,3 +236,29 @@ async def test_retrieve_with_custom_top_k(
     results = await vector_search_service.retrieve("test", top_k=1)
 
     assert len(results) == 1
+
+
+@pytest.mark.asyncio
+async def test_has_embedding(
+    vector_search_service: LocalVectorSearchService,
+    session: AsyncSession,
+):
+    index_id, file_id = await create_dummy_db_file(session)
+
+    snippet1 = Snippet(
+        index_id=index_id, file_id=file_id, content="python programming language"
+    )
+
+    session.add(snippet1)
+    await session.commit()
+
+    assert not await vector_search_service.has_embedding(
+        snippet1.id, EmbeddingType.CODE
+    )
+
+    test_data = [
+        VectorSearchRequest(snippet_id=snippet1.id, text=snippet1.content),
+    ]
+    [gen async for gen in vector_search_service.index(test_data)]
+
+    assert await vector_search_service.has_embedding(snippet1.id, EmbeddingType.CODE)

--- a/tests/kodit/enrichment/enrichment_provider/local_enrichment_provider_test.py
+++ b/tests/kodit/enrichment/enrichment_provider/local_enrichment_provider_test.py
@@ -1,0 +1,194 @@
+"""Tests for the LocalEnrichmentProvider."""
+
+import sys
+from types import ModuleType
+
+import pytest
+
+from kodit.enrichment.enrichment_provider.enrichment_provider import EnrichmentRequest
+from kodit.enrichment.enrichment_provider.local_enrichment_provider import (
+    LocalEnrichmentProvider,
+    DEFAULT_ENRICHMENT_MODEL,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures & helpers
+# ---------------------------------------------------------------------------
+
+
+class _DummyEncoding(dict):
+    """Minimal stand-in for a HuggingFace *BatchEncoding*."""
+
+    def to(self, _device):  # pragma: no cover – trivial
+        """HF encodings implement .to(device); return self for compatibility."""
+        return self
+
+
+class _DummyTokenizer:  # pylint: disable=too-few-public-methods
+    """Very small stub for *AutoTokenizer* used in tests."""
+
+    def apply_chat_template(self, messages, **_kwargs):  # noqa: D401
+        """Return the user message content so tests stay deterministic."""
+        user_msg = next(m for m in messages if m["role"] == "user")
+        content = user_msg["content"]
+        assert isinstance(content, str)
+        return str(content)
+
+    def __call__(self, batch, **_kwargs):  # noqa: D401
+        # *batch* is a list of EmbeddingRequest objects – ignore the text.
+        return _DummyEncoding({"input_ids": [[idx] for idx, _ in enumerate(batch)]})
+
+    def decode(self, _ids, **_kwargs):  # noqa: D401
+        return "mocked_enrichment"
+
+
+class _DummyModel:  # pylint: disable=too-few-public-methods
+    """Tiny stand-in for *AutoModelForCausalLM*."""
+
+    device = "cpu"
+
+    def generate(self, input_ids=None, **_kwargs):  # noqa: D401
+        """Return *input_ids* with an extra dummy token appended.
+
+        Static analysis complains if *input_ids* might be *None*, so default to an
+        empty list in that case.
+        """
+
+        class _DummyTensor(list):
+            """List-like object that mimics a torch Tensor for `.tolist()` calls."""
+
+            def __getitem__(self, key):  # noqa: D401
+                result = super().__getitem__(key)
+                # Preserve DummyTensor behaviour for slices so `.tolist()` works.
+                if isinstance(key, slice):
+                    return _DummyTensor(result)
+                return result
+
+            def tolist(self):  # noqa: D401
+                return list(self)
+
+        input_ids = input_ids or []
+        return [_DummyTensor(ids + [999]) for ids in input_ids]
+
+
+@pytest.fixture(autouse=True)
+def _patch_transformers(monkeypatch):  # noqa: D401
+    """Patch *transformers* modules so no large downloads happen during tests."""
+
+    # Build module hierarchy expected by the provider.
+    transformers_mod = ModuleType("transformers")
+    models_mod = ModuleType("transformers.models")
+    auto_mod = ModuleType("transformers.models.auto")
+    tok_auto_mod = ModuleType("transformers.models.auto.tokenization_auto")
+    model_auto_mod = ModuleType("transformers.models.auto.modeling_auto")
+
+    # Inject dummy classes.
+    class _DummyAutoTokenizer:  # pylint: disable=too-few-public-methods
+        @staticmethod
+        def from_pretrained(*_args, **_kwargs):  # noqa: D401
+            return _DummyTokenizer()
+
+    class _DummyAutoModelForCausalLM:  # pylint: disable=too-few-public-methods
+        @staticmethod
+        def from_pretrained(*_args, **_kwargs):  # noqa: D401
+            return _DummyModel()
+
+    tok_auto_mod.AutoTokenizer = _DummyAutoTokenizer  # type: ignore[attr-defined]
+    model_auto_mod.AutoModelForCausalLM = _DummyAutoModelForCausalLM  # type: ignore[attr-defined]
+
+    # Register the modules so Python's import machinery can find them.
+    for mod in [
+        ("transformers", transformers_mod),
+        ("transformers.models", models_mod),
+        ("transformers.models.auto", auto_mod),
+        ("transformers.models.auto.tokenization_auto", tok_auto_mod),
+        ("transformers.models.auto.modeling_auto", model_auto_mod),
+    ]:
+        sys.modules[mod[0]] = mod[1]
+
+
+@pytest.fixture
+def provider():  # noqa: D401
+    """Return a *LocalEnrichmentProvider* with default settings."""
+    return LocalEnrichmentProvider()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_initialization_default():  # noqa: D401
+    """Provider initialises with the correct default model."""
+    prov = LocalEnrichmentProvider()
+    assert prov.model_name == DEFAULT_ENRICHMENT_MODEL
+
+
+@pytest.mark.asyncio
+async def test_initialization_custom():  # noqa: D401
+    """Custom model name propagates correctly."""
+    custom = "my-fancy-model"
+    prov = LocalEnrichmentProvider(model_name=custom)
+    assert prov.model_name == custom
+
+
+@pytest.mark.asyncio
+async def test_enrich_single_text(provider):  # noqa: D401
+    text = "def hello(): print('Hello, world!')"
+    enriched = [
+        resp
+        async for resp in provider.enrich([EnrichmentRequest(snippet_id=0, text=text)])
+    ]
+
+    assert len(enriched) == 1
+    assert isinstance(enriched[0].text, str)
+    assert len(enriched[0].text) > 0
+
+
+@pytest.mark.asyncio
+async def test_enrich_multiple_texts(provider):  # noqa: D401
+    texts = [
+        "def hello(): print('Hello, world!')",
+        "def add(a, b): return a + b",
+        "def multiply(a, b): return a * b",
+    ]
+    enriched = [
+        resp
+        async for resp in provider.enrich(
+            [EnrichmentRequest(snippet_id=i, text=t) for i, t in enumerate(texts)]
+        )
+    ]
+
+    assert len(enriched) == 3
+    assert all(isinstance(r.text, str) for r in enriched)
+    assert all(len(r.text) > 0 for r in enriched)
+
+
+@pytest.mark.asyncio
+async def test_enrich_empty_list(provider):  # noqa: D401
+    enriched = [resp async for resp in provider.enrich([])]
+    assert len(enriched) == 0
+
+
+@pytest.mark.asyncio
+async def test_enrich_empty_string_filtered(provider):  # noqa: D401
+    """Empty strings should be ignored and return no enrichment."""
+    enriched = [
+        resp
+        async for resp in provider.enrich([EnrichmentRequest(snippet_id=0, text="")])
+    ]
+    assert len(enriched) == 0
+
+
+@pytest.mark.asyncio
+async def test_enrich_order_consistency(provider):  # noqa: D401
+    """Ensure order of outputs matches order of inputs despite batching."""
+    requests = [
+        EnrichmentRequest(snippet_id=i, text=f"def test_{i}(): pass") for i in range(20)
+    ]
+    enriched = [resp async for resp in provider.enrich(requests)]
+
+    assert [r.snippet_id for r in enriched] == list(range(20))
+    assert all(isinstance(r.text, str) and r.text for r in enriched)

--- a/tests/kodit/enrichment/enrichment_provider/local_enrichment_provider_test.py
+++ b/tests/kodit/enrichment/enrichment_provider/local_enrichment_provider_test.py
@@ -76,7 +76,7 @@ class _DummyModel:  # pylint: disable=too-few-public-methods
         return _DummyTensor([[999]])
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture
 def _patch_transformers(request):  # noqa: D401
     """Patch *transformers* modules so no large downloads happen during tests."""
     if "no_patch" in request.keywords:


### PR DESCRIPTION
Introduced streaming to enable progress bars for embedding and in the process found a massive problem with the batching of big files. Fixed that and from a UX perspective, it's much faster.

Improves #118, but doesn't totally fix it. There's still lots of optimisation that can be done, e.g. not reindexing old files.