### PR TITLE
fix(indexing): sanitise long repo names so it doesn't break on Windows

### DIFF
--- a/src/kodit/infrastructure/cloning/git/working_copy.py
+++ b/src/kodit/infrastructure/cloning/git/working_copy.py
@@ -1,5 +1,6 @@
 """Working copy provider for git-based sources."""
 
+import hashlib
 from pathlib import Path
 
 import git
@@ -21,8 +22,10 @@ class GitWorkingCopyProvider:
         # Sanitize the URI for directory name to prevent credential leaks
         sanitized_uri = sanitize_git_url(uri)
 
-        # Create a unique directory name for the clone using the sanitized URI
-        clone_path = self.clone_dir / sanitized_uri.replace("/", "_").replace(":", "_")
+        # Use a repeatable, short sha256 hash of the sanitized URI for the directory name
+        dir_hash = hashlib.sha256(sanitized_uri.encode("utf-8")).hexdigest()[:16]
+        dir_name = f"repo-{dir_hash}"
+        clone_path = self.clone_dir / dir_name
         clone_path.mkdir(parents=True, exist_ok=True)
 
         try:


### PR DESCRIPTION
Fixes #146
