### PR TITLE
feat(search): add filters to search requests

### DIFF
--- a/.cursor/rules/style.mdc
+++ b/.cursor/rules/style.mdc
@@ -1,0 +1,11 @@
+---
+description: 
+globs: 
+alwaysApply: true
+---
+Please maintain the following coding standards while developing code:
+
+1. This project uses a domain-driven design approach. Please consider in which layer
+   your code belongs.
+2. Run `uv run ruff check --fix` to lint the code.
+3. Run `uv run pytest ...` to test the code.

--- a/src/kodit/application/services/indexing_application_service.py
+++ b/src/kodit/application/services/indexing_application_service.py
@@ -328,6 +328,20 @@ class IndexingApplicationService:
         """
         log_event("kodit.index.search")
 
+        # If filters are provided, use the snippet repository search
+        if request.filters:
+            snippet_results = await self.snippet_application_service.search(request)
+            return [
+                MultiSearchResult(
+                    id=snippet.id,
+                    uri=snippet.source_uri,
+                    content=snippet.content,
+                    original_scores=[1.0],  # Default score for filtered results
+                )
+                for snippet in snippet_results
+            ]
+
+        # Otherwise use the existing fusion logic
         fusion_list: list[list[FusionRequest]] = []
         if request.keywords:
             # Gather results for each keyword

--- a/src/kodit/application/services/snippet_application_service.py
+++ b/src/kodit/application/services/snippet_application_service.py
@@ -18,7 +18,11 @@ from kodit.domain.repositories import FileRepository, SnippetRepository
 from kodit.domain.services.snippet_extraction_service import (
     SnippetExtractionDomainService,
 )
-from kodit.domain.value_objects import SnippetExtractionRequest, SnippetListItem
+from kodit.domain.value_objects import (
+    MultiSearchRequest,
+    SnippetExtractionRequest,
+    SnippetListItem,
+)
 from kodit.reporting import Reporter
 
 
@@ -167,3 +171,15 @@ class SnippetApplicationService:
                 command.file_path, command.source_uri
             )
         )
+
+    async def search(self, request: MultiSearchRequest) -> list[SnippetListItem]:
+        """Search snippets with filters.
+
+        Args:
+            request: The search request containing queries and optional filters.
+
+        Returns:
+            List of SnippetListItem instances matching the search criteria.
+
+        """
+        return list(await self.snippet_repository.search(request))

--- a/src/kodit/cli.py
+++ b/src/kodit/cli.py
@@ -194,7 +194,7 @@ def search() -> None:
 )
 @with_app_context
 @with_session
-async def code(
+async def code(  # noqa: PLR0913
     session: AsyncSession,
     app_context: AppContext,
     query: str,
@@ -274,7 +274,7 @@ async def code(
 )
 @with_app_context
 @with_session
-async def keyword(
+async def keyword(  # noqa: PLR0913
     session: AsyncSession,
     app_context: AppContext,
     keywords: list[str],
@@ -351,7 +351,7 @@ async def keyword(
 )
 @with_app_context
 @with_session
-async def text(
+async def text(  # noqa: PLR0913
     session: AsyncSession,
     app_context: AppContext,
     query: str,

--- a/src/kodit/cli.py
+++ b/src/kodit/cli.py
@@ -223,21 +223,13 @@ async def code(  # noqa: PLR0913
     )
 
     # Create filters if any filter parameters are provided
-    filters = None
-    if any([language, author, created_after, created_before, source_repo]):
-        from datetime import datetime
-
-        filters = SnippetSearchFilters(
-            language=language,
-            author=author,
-            created_after=datetime.fromisoformat(created_after)
-            if created_after
-            else None,
-            created_before=datetime.fromisoformat(created_before)
-            if created_before
-            else None,
-            source_repo=source_repo,
-        )
+    filters = SnippetSearchFilters.from_cli_params(
+        language=language,
+        author=author,
+        created_after=created_after,
+        created_before=created_before,
+        source_repo=source_repo,
+    )
 
     snippets = await service.search(
         MultiSearchRequest(code_query=query, top_k=top_k, filters=filters)
@@ -300,21 +292,13 @@ async def keyword(  # noqa: PLR0913
     )
 
     # Create filters if any filter parameters are provided
-    filters = None
-    if any([language, author, created_after, created_before, source_repo]):
-        from datetime import datetime
-
-        filters = SnippetSearchFilters(
-            language=language,
-            author=author,
-            created_after=datetime.fromisoformat(created_after)
-            if created_after
-            else None,
-            created_before=datetime.fromisoformat(created_before)
-            if created_before
-            else None,
-            source_repo=source_repo,
-        )
+    filters = SnippetSearchFilters.from_cli_params(
+        language=language,
+        author=author,
+        created_after=created_after,
+        created_before=created_before,
+        source_repo=source_repo,
+    )
 
     snippets = await service.search(
         MultiSearchRequest(keywords=keywords, top_k=top_k, filters=filters)
@@ -380,21 +364,13 @@ async def text(  # noqa: PLR0913
     )
 
     # Create filters if any filter parameters are provided
-    filters = None
-    if any([language, author, created_after, created_before, source_repo]):
-        from datetime import datetime
-
-        filters = SnippetSearchFilters(
-            language=language,
-            author=author,
-            created_after=datetime.fromisoformat(created_after)
-            if created_after
-            else None,
-            created_before=datetime.fromisoformat(created_before)
-            if created_before
-            else None,
-            source_repo=source_repo,
-        )
+    filters = SnippetSearchFilters.from_cli_params(
+        language=language,
+        author=author,
+        created_after=created_after,
+        created_before=created_before,
+        source_repo=source_repo,
+    )
 
     snippets = await service.search(
         MultiSearchRequest(text_query=query, top_k=top_k, filters=filters)
@@ -464,21 +440,13 @@ async def hybrid(  # noqa: PLR0913
     keywords_list = [k.strip().lower() for k in keywords.split(",")]
 
     # Create filters if any filter parameters are provided
-    filters = None
-    if any([language, author, created_after, created_before, source_repo]):
-        from datetime import datetime
-
-        filters = SnippetSearchFilters(
-            language=language,
-            author=author,
-            created_after=datetime.fromisoformat(created_after)
-            if created_after
-            else None,
-            created_before=datetime.fromisoformat(created_before)
-            if created_before
-            else None,
-            source_repo=source_repo,
-        )
+    filters = SnippetSearchFilters.from_cli_params(
+        language=language,
+        author=author,
+        created_after=created_after,
+        created_before=created_before,
+        source_repo=source_repo,
+    )
 
     snippets = await service.search(
         MultiSearchRequest(

--- a/src/kodit/cli.py
+++ b/src/kodit/cli.py
@@ -24,7 +24,7 @@ from kodit.config import (
 )
 from kodit.domain.errors import EmptySourceError
 from kodit.domain.services.source_service import SourceService
-from kodit.domain.value_objects import MultiSearchRequest
+from kodit.domain.value_objects import MultiSearchRequest, SnippetSearchFilters
 from kodit.infrastructure.indexing.indexing_factory import (
     create_indexing_application_service,
 )
@@ -179,6 +179,19 @@ def search() -> None:
 @search.command()
 @click.argument("query")
 @click.option("--top-k", default=10, help="Number of snippets to retrieve")
+@click.option(
+    "--language", help="Filter by programming language (e.g., python, go, javascript)"
+)
+@click.option("--author", help="Filter by author name")
+@click.option(
+    "--created-after", help="Filter snippets created after this date (YYYY-MM-DD)"
+)
+@click.option(
+    "--created-before", help="Filter snippets created before this date (YYYY-MM-DD)"
+)
+@click.option(
+    "--source-repo", help="Filter by source repository (e.g., github.com/example/repo)"
+)
 @with_app_context
 @with_session
 async def code(
@@ -186,6 +199,11 @@ async def code(
     app_context: AppContext,
     query: str,
     top_k: int,
+    language: str | None,
+    author: str | None,
+    created_after: str | None,
+    created_before: str | None,
+    source_repo: str | None,
 ) -> None:
     """Search for snippets using semantic code search.
 
@@ -204,7 +222,26 @@ async def code(
         snippet_application_service=snippet_service,
     )
 
-    snippets = await service.search(MultiSearchRequest(code_query=query, top_k=top_k))
+    # Create filters if any filter parameters are provided
+    filters = None
+    if any([language, author, created_after, created_before, source_repo]):
+        from datetime import datetime
+
+        filters = SnippetSearchFilters(
+            language=language,
+            author=author,
+            created_after=datetime.fromisoformat(created_after)
+            if created_after
+            else None,
+            created_before=datetime.fromisoformat(created_before)
+            if created_before
+            else None,
+            source_repo=source_repo,
+        )
+
+    snippets = await service.search(
+        MultiSearchRequest(code_query=query, top_k=top_k, filters=filters)
+    )
 
     if len(snippets) == 0:
         click.echo("No snippets found")
@@ -222,6 +259,19 @@ async def code(
 @search.command()
 @click.argument("keywords", nargs=-1)
 @click.option("--top-k", default=10, help="Number of snippets to retrieve")
+@click.option(
+    "--language", help="Filter by programming language (e.g., python, go, javascript)"
+)
+@click.option("--author", help="Filter by author name")
+@click.option(
+    "--created-after", help="Filter snippets created after this date (YYYY-MM-DD)"
+)
+@click.option(
+    "--created-before", help="Filter snippets created before this date (YYYY-MM-DD)"
+)
+@click.option(
+    "--source-repo", help="Filter by source repository (e.g., github.com/example/repo)"
+)
 @with_app_context
 @with_session
 async def keyword(
@@ -229,6 +279,11 @@ async def keyword(
     app_context: AppContext,
     keywords: list[str],
     top_k: int,
+    language: str | None,
+    author: str | None,
+    created_after: str | None,
+    created_before: str | None,
+    source_repo: str | None,
 ) -> None:
     """Search for snippets using keyword search."""
     log_event("kodit.cli.search.keyword")
@@ -244,7 +299,26 @@ async def keyword(
         snippet_application_service=snippet_service,
     )
 
-    snippets = await service.search(MultiSearchRequest(keywords=keywords, top_k=top_k))
+    # Create filters if any filter parameters are provided
+    filters = None
+    if any([language, author, created_after, created_before, source_repo]):
+        from datetime import datetime
+
+        filters = SnippetSearchFilters(
+            language=language,
+            author=author,
+            created_after=datetime.fromisoformat(created_after)
+            if created_after
+            else None,
+            created_before=datetime.fromisoformat(created_before)
+            if created_before
+            else None,
+            source_repo=source_repo,
+        )
+
+    snippets = await service.search(
+        MultiSearchRequest(keywords=keywords, top_k=top_k, filters=filters)
+    )
 
     if len(snippets) == 0:
         click.echo("No snippets found")
@@ -262,6 +336,19 @@ async def keyword(
 @search.command()
 @click.argument("query")
 @click.option("--top-k", default=10, help="Number of snippets to retrieve")
+@click.option(
+    "--language", help="Filter by programming language (e.g., python, go, javascript)"
+)
+@click.option("--author", help="Filter by author name")
+@click.option(
+    "--created-after", help="Filter snippets created after this date (YYYY-MM-DD)"
+)
+@click.option(
+    "--created-before", help="Filter snippets created before this date (YYYY-MM-DD)"
+)
+@click.option(
+    "--source-repo", help="Filter by source repository (e.g., github.com/example/repo)"
+)
 @with_app_context
 @with_session
 async def text(
@@ -269,6 +356,11 @@ async def text(
     app_context: AppContext,
     query: str,
     top_k: int,
+    language: str | None,
+    author: str | None,
+    created_after: str | None,
+    created_before: str | None,
+    source_repo: str | None,
 ) -> None:
     """Search for snippets using semantic text search.
 
@@ -287,7 +379,26 @@ async def text(
         snippet_application_service=snippet_service,
     )
 
-    snippets = await service.search(MultiSearchRequest(text_query=query, top_k=top_k))
+    # Create filters if any filter parameters are provided
+    filters = None
+    if any([language, author, created_after, created_before, source_repo]):
+        from datetime import datetime
+
+        filters = SnippetSearchFilters(
+            language=language,
+            author=author,
+            created_after=datetime.fromisoformat(created_after)
+            if created_after
+            else None,
+            created_before=datetime.fromisoformat(created_before)
+            if created_before
+            else None,
+            source_repo=source_repo,
+        )
+
+    snippets = await service.search(
+        MultiSearchRequest(text_query=query, top_k=top_k, filters=filters)
+    )
 
     if len(snippets) == 0:
         click.echo("No snippets found")
@@ -307,6 +418,19 @@ async def text(
 @click.option("--keywords", required=True, help="Comma separated list of keywords")
 @click.option("--code", required=True, help="Semantic code search query")
 @click.option("--text", required=True, help="Semantic text search query")
+@click.option(
+    "--language", help="Filter by programming language (e.g., python, go, javascript)"
+)
+@click.option("--author", help="Filter by author name")
+@click.option(
+    "--created-after", help="Filter snippets created after this date (YYYY-MM-DD)"
+)
+@click.option(
+    "--created-before", help="Filter snippets created before this date (YYYY-MM-DD)"
+)
+@click.option(
+    "--source-repo", help="Filter by source repository (e.g., github.com/example/repo)"
+)
 @with_app_context
 @with_session
 async def hybrid(  # noqa: PLR0913
@@ -316,6 +440,11 @@ async def hybrid(  # noqa: PLR0913
     keywords: str,
     code: str,
     text: str,
+    language: str | None,
+    author: str | None,
+    created_after: str | None,
+    created_before: str | None,
+    source_repo: str | None,
 ) -> None:
     """Search for snippets using hybrid search."""
     log_event("kodit.cli.search.hybrid")
@@ -334,12 +463,30 @@ async def hybrid(  # noqa: PLR0913
     # Parse keywords into a list of strings
     keywords_list = [k.strip().lower() for k in keywords.split(",")]
 
+    # Create filters if any filter parameters are provided
+    filters = None
+    if any([language, author, created_after, created_before, source_repo]):
+        from datetime import datetime
+
+        filters = SnippetSearchFilters(
+            language=language,
+            author=author,
+            created_after=datetime.fromisoformat(created_after)
+            if created_after
+            else None,
+            created_before=datetime.fromisoformat(created_before)
+            if created_before
+            else None,
+            source_repo=source_repo,
+        )
+
     snippets = await service.search(
         MultiSearchRequest(
             keywords=keywords_list,
             code_query=code,
             text_query=text,
             top_k=top_k,
+            filters=filters,
         )
     )
 

--- a/src/kodit/domain/entities.py
+++ b/src/kodit/domain/entities.py
@@ -121,22 +121,24 @@ class File(Base, CommonMixin):
         created_at: datetime,
         updated_at: datetime,
         source_id: int,
+        mime_type: str,
+        uri: str,
         cloned_path: str,
-        mime_type: str = "",
-        uri: str = "",
-        sha256: str = "",
-        size_bytes: int = 0,
+        sha256: str,
+        size_bytes: int,
+        extension: str,
     ) -> None:
         """Initialize a new File instance for typing purposes."""
         super().__init__()
         self.created_at = created_at
         self.updated_at = updated_at
         self.source_id = source_id
-        self.cloned_path = cloned_path
         self.mime_type = mime_type
         self.uri = uri
+        self.cloned_path = cloned_path
         self.sha256 = sha256
         self.size_bytes = size_bytes
+        self.extension = extension
 
 
 class EmbeddingType(Enum):

--- a/src/kodit/domain/repositories.py
+++ b/src/kodit/domain/repositories.py
@@ -11,7 +11,10 @@ from kodit.domain.entities import (
     Source,
     SourceType,
 )
-from kodit.domain.value_objects import SnippetListItem
+from kodit.domain.value_objects import (
+    MultiSearchRequest,
+    SnippetListItem,
+)
 
 T = TypeVar("T")
 
@@ -100,6 +103,18 @@ class SnippetRepository(GenericRepository[Snippet]):
 
         Returns:
             A sequence of SnippetListItem instances matching the criteria
+
+        """
+        raise NotImplementedError
+
+    async def search(self, request: MultiSearchRequest) -> Sequence[SnippetListItem]:
+        """Search snippets with filters.
+
+        Args:
+            request: The search request containing queries and optional filters.
+
+        Returns:
+            A sequence of SnippetListItem instances matching the search criteria.
 
         """
         raise NotImplementedError

--- a/src/kodit/domain/value_objects.py
+++ b/src/kodit/domain/value_objects.py
@@ -91,6 +91,17 @@ VectorIndexRequest = IndexRequest
 VectorSearchQueryRequest = SimpleSearchRequest
 
 
+@dataclass(frozen=True)
+class SnippetSearchFilters:
+    """Value object for filtering snippet search results."""
+
+    language: str | None = None
+    author: str | None = None
+    created_after: datetime | None = None
+    created_before: datetime | None = None
+    source_repo: str | None = None
+
+
 @dataclass
 class MultiSearchRequest:
     """Domain model for multi-modal search request."""
@@ -99,6 +110,7 @@ class MultiSearchRequest:
     text_query: str | None = None
     code_query: str | None = None
     keywords: list[str] | None = None
+    filters: SnippetSearchFilters | None = None
 
 
 @dataclass

--- a/src/kodit/domain/value_objects.py
+++ b/src/kodit/domain/value_objects.py
@@ -106,6 +106,66 @@ class SnippetSearchFilters:
     created_before: datetime | None = None
     source_repo: str | None = None
 
+    @classmethod
+    def from_cli_params(
+        cls,
+        language: str | None = None,
+        author: str | None = None,
+        created_after: str | None = None,
+        created_before: str | None = None,
+        source_repo: str | None = None,
+    ) -> "SnippetSearchFilters | None":
+        """Create SnippetSearchFilters from CLI parameters.
+
+        Args:
+            language: Programming language filter (e.g., python, go, javascript)
+            author: Author name filter
+            created_after: Date string in YYYY-MM-DD format for filtering snippets
+            created after
+            created_before: Date string in YYYY-MM-DD format for filtering snippets
+            created before
+            source_repo: Source repository filter (e.g., github.com/example/repo)
+
+        Returns:
+            SnippetSearchFilters instance if any filters are provided, None otherwise
+
+        Raises:
+            ValueError: If date strings are in invalid format
+
+        """
+        # Only create filters if at least one parameter is provided
+        if not any([language, author, created_after, created_before, source_repo]):
+            return None
+
+        # Parse date strings if provided
+        parsed_created_after = None
+        if created_after:
+            try:
+                parsed_created_after = datetime.fromisoformat(created_after)
+            except ValueError as e:
+                raise ValueError(
+                    f"Invalid date format for created_after: {created_after}. "
+                    "Expected ISO 8601 format (YYYY-MM-DD)"
+                ) from e
+
+        parsed_created_before = None
+        if created_before:
+            try:
+                parsed_created_before = datetime.fromisoformat(created_before)
+            except ValueError as e:
+                raise ValueError(
+                    f"Invalid date format for created_before: {created_before}. "
+                    "Expected ISO 8601 format (YYYY-MM-DD)"
+                ) from e
+
+        return cls(
+            language=language,
+            author=author,
+            created_after=parsed_created_after,
+            created_before=parsed_created_before,
+            source_repo=source_repo,
+        )
+
 
 @dataclass
 class MultiSearchRequest:

--- a/src/kodit/domain/value_objects.py
+++ b/src/kodit/domain/value_objects.py
@@ -4,7 +4,12 @@ from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
+from typing import Any, ClassVar
 
+from sqlalchemy import JSON, DateTime, Integer, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from kodit.domain.entities import Base
 from kodit.domain.enums import SnippetExtractionStrategy
 
 
@@ -235,3 +240,209 @@ class SnippetListItem:
     file_path: str
     content: str
     source_uri: str
+
+
+class LanguageMapping:
+    """Value object for language-to-extension mappings.
+
+    This encapsulates the domain knowledge of programming languages and their
+    associated file extensions. It provides bidirectional mapping capabilities
+    and is designed to be immutable and reusable across the application.
+    """
+
+    # Comprehensive mapping of language names to their file extensions
+    _LANGUAGE_TO_EXTENSIONS: ClassVar[dict[str, list[str]]] = {
+        "python": ["py", "pyw", "pyx", "pxd"],
+        "go": ["go"],
+        "javascript": ["js", "jsx", "mjs"],
+        "typescript": ["ts", "tsx"],
+        "java": ["java"],
+        "csharp": ["cs"],
+        "cpp": ["cpp", "cc", "cxx", "hpp"],
+        "c": ["c", "h"],
+        "rust": ["rs"],
+        "php": ["php"],
+        "ruby": ["rb"],
+        "swift": ["swift"],
+        "kotlin": ["kt", "kts"],
+        "scala": ["scala"],
+        "r": ["r", "R"],
+        "matlab": ["m"],
+        "perl": ["pl", "pm"],
+        "bash": ["sh", "bash"],
+        "powershell": ["ps1"],
+        "sql": ["sql"],
+        "html": ["html", "htm"],
+        "css": ["css", "scss", "sass"],
+        "yaml": ["yml", "yaml"],
+        "json": ["json"],
+        "xml": ["xml"],
+        "markdown": ["md", "markdown"],
+    }
+
+    @classmethod
+    def get_extensions_for_language(cls, language: str) -> list[str]:
+        """Get file extensions for a given language.
+
+        Args:
+            language: The programming language name (case-insensitive)
+
+        Returns:
+            List of file extensions (without leading dots) for the language
+
+        Raises:
+            ValueError: If the language is not supported
+
+        """
+        language_lower = language.lower()
+        extensions = cls._LANGUAGE_TO_EXTENSIONS.get(language_lower)
+
+        if extensions is None:
+            raise ValueError(f"Unsupported language: {language}")
+
+        return extensions.copy()  # Return a copy to prevent modification
+
+    @classmethod
+    def get_language_for_extension(cls, extension: str) -> str:
+        """Get language for a given file extension.
+
+        Args:
+            extension: The file extension (with or without leading dot)
+
+        Returns:
+            The programming language name
+
+        Raises:
+            ValueError: If the extension is not supported
+
+        """
+        # Remove leading dot if present
+        ext_clean = extension.removeprefix(".").lower()
+
+        # Search through all languages to find matching extension
+        for language, extensions in cls._LANGUAGE_TO_EXTENSIONS.items():
+            if ext_clean in extensions:
+                return language
+
+        raise ValueError(f"Unsupported file extension: {extension}")
+
+    @classmethod
+    def get_extension_to_language_map(cls) -> dict[str, str]:
+        """Get a mapping from file extensions to language names.
+
+        Returns:
+            Dictionary mapping file extensions (without leading dots) to language names
+
+        """
+        extension_map = {}
+        for language, extensions in cls._LANGUAGE_TO_EXTENSIONS.items():
+            for extension in extensions:
+                extension_map[extension] = language
+        return extension_map
+
+    @classmethod
+    def get_supported_languages(cls) -> list[str]:
+        """Get list of all supported programming languages.
+
+        Returns:
+            List of supported language names
+
+        """
+        return list(cls._LANGUAGE_TO_EXTENSIONS.keys())
+
+    @classmethod
+    def get_supported_extensions(cls) -> list[str]:
+        """Get list of all supported file extensions.
+
+        Returns:
+            List of supported file extensions (without leading dots)
+
+        """
+        extensions = []
+        for ext_list in cls._LANGUAGE_TO_EXTENSIONS.values():
+            extensions.extend(ext_list)
+        return extensions
+
+    @classmethod
+    def is_supported_language(cls, language: str) -> bool:
+        """Check if a language is supported.
+
+        Args:
+            language: The programming language name (case-insensitive)
+
+        Returns:
+            True if the language is supported, False otherwise
+
+        """
+        return language.lower() in cls._LANGUAGE_TO_EXTENSIONS
+
+    @classmethod
+    def is_supported_extension(cls, extension: str) -> bool:
+        """Check if a file extension is supported.
+
+        Args:
+            extension: The file extension (with or without leading dot)
+
+        Returns:
+            True if the extension is supported, False otherwise
+
+        """
+        try:
+            cls.get_language_for_extension(extension)
+        except ValueError:
+            return False
+        return True
+
+    @classmethod
+    def get_extensions_with_fallback(cls, language: str) -> list[str]:
+        """Get file extensions for a language, falling back to passed language name.
+
+        Args:
+            language: The programming language name (case-insensitive)
+
+        Returns:
+            List of file extensions (without leading dots) for the language, or
+            [language.lower()] if not found.
+
+        """
+        language_lower = language.lower()
+        if cls.is_supported_language(language_lower):
+            return cls.get_extensions_for_language(language_lower)
+        return [language_lower]
+
+
+# Database models for value objects
+class BM25DocumentModel(Base):
+    """BM25 document model."""
+
+    __tablename__ = "bm25_documents"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    document_metadata: Mapped[dict[str, Any] | None] = mapped_column(
+        JSON, nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+
+
+class VectorDocumentModel(Base):
+    """Vector document model."""
+
+    __tablename__ = "vector_documents"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    document_metadata: Mapped[dict[str, Any] | None] = mapped_column(
+        JSON, nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )

--- a/src/kodit/infrastructure/cloning/metadata.py
+++ b/src/kodit/infrastructure/cloning/metadata.py
@@ -38,6 +38,7 @@ class BaseFileMetadataExtractor:
                 uri=path.as_uri(),
                 sha256=sha,
                 size_bytes=len(content),
+                extension=path.suffix.removeprefix(".").lower(),
             )
 
     async def _get_timestamps(

--- a/src/kodit/infrastructure/snippet_extraction/snippet_extraction_factory.py
+++ b/src/kodit/infrastructure/snippet_extraction/snippet_extraction_factory.py
@@ -9,6 +9,7 @@ from kodit.domain.repositories import FileRepository, SnippetRepository
 from kodit.domain.services.snippet_extraction_service import (
     SnippetExtractionDomainService,
 )
+from kodit.domain.value_objects import LanguageMapping
 from kodit.infrastructure.snippet_extraction.language_detection_service import (
     FileSystemLanguageDetectionService,
 )
@@ -31,37 +32,8 @@ def create_snippet_extraction_domain_service() -> SnippetExtractionDomainService
         Configured snippet extraction domain service
 
     """
-    # Language mapping from the existing languages module
-    language_map = {
-        # JavaScript/TypeScript
-        "js": "javascript",
-        "jsx": "javascript",
-        "ts": "typescript",
-        "tsx": "typescript",
-        # Python
-        "py": "python",
-        # Rust
-        "rs": "rust",
-        # Go
-        "go": "go",
-        # C/C++
-        "cpp": "cpp",
-        "hpp": "cpp",
-        "c": "c",
-        "h": "c",
-        # C#
-        "cs": "csharp",
-        # Ruby
-        "rb": "ruby",
-        # Java
-        "java": "java",
-        # PHP
-        "php": "php",
-        # Swift
-        "swift": "swift",
-        # Kotlin
-        "kt": "kotlin",
-    }
+    # Use the unified language mapping from the domain layer
+    language_map = LanguageMapping.get_extension_to_language_map()
 
     # Create infrastructure services
     language_detector = FileSystemLanguageDetectionService(language_map)

--- a/src/kodit/infrastructure/sqlalchemy/snippet_repository.py
+++ b/src/kodit/infrastructure/sqlalchemy/snippet_repository.py
@@ -182,38 +182,38 @@ class SqlAlchemySnippetRepository(SnippetRepository):
 
             # Language filter (using file extension)
             if filters.language:
-                # Map common language names to file extensions
+                # Map common language names to file extensions (no leading dot)
                 language_extensions = {
-                    "python": [".py", ".pyw", ".pyx", ".pxd"],
-                    "go": [".go"],
-                    "javascript": [".js", ".jsx", ".mjs"],
-                    "typescript": [".ts", ".tsx"],
-                    "java": [".java"],
-                    "csharp": [".cs"],
-                    "cpp": [".cpp", ".cc", ".cxx", ".hpp", ".h"],
-                    "c": [".c", ".h"],
-                    "rust": [".rs"],
-                    "php": [".php"],
-                    "ruby": [".rb"],
-                    "swift": [".swift"],
-                    "kotlin": [".kt", ".kts"],
-                    "scala": [".scala"],
-                    "r": [".r", ".R"],
-                    "matlab": [".m"],
-                    "perl": [".pl", ".pm"],
-                    "bash": [".sh", ".bash"],
-                    "powershell": [".ps1"],
-                    "sql": [".sql"],
-                    "html": [".html", ".htm"],
-                    "css": [".css", ".scss", ".sass"],
-                    "yaml": [".yml", ".yaml"],
-                    "json": [".json"],
-                    "xml": [".xml"],
-                    "markdown": [".md", ".markdown"],
+                    "python": ["py", "pyw", "pyx", "pxd"],
+                    "go": ["go"],
+                    "javascript": ["js", "jsx", "mjs"],
+                    "typescript": ["ts", "tsx"],
+                    "java": ["java"],
+                    "csharp": ["cs"],
+                    "cpp": ["cpp", "cc", "cxx", "hpp", "h"],
+                    "c": ["c", "h"],
+                    "rust": ["rs"],
+                    "php": ["php"],
+                    "ruby": ["rb"],
+                    "swift": ["swift"],
+                    "kotlin": ["kt", "kts"],
+                    "scala": ["scala"],
+                    "r": ["r", "R"],
+                    "matlab": ["m"],
+                    "perl": ["pl", "pm"],
+                    "bash": ["sh", "bash"],
+                    "powershell": ["ps1"],
+                    "sql": ["sql"],
+                    "html": ["html", "htm"],
+                    "css": ["css", "scss", "sass"],
+                    "yaml": ["yml", "yaml"],
+                    "json": ["json"],
+                    "xml": ["xml"],
+                    "markdown": ["md", "markdown"],
                 }
 
                 extensions = language_extensions.get(
-                    filters.language.lower(), [f".{filters.language}"]
+                    filters.language.lower(), [filters.language.lower()]
                 )
                 query = query.where(File.extension.in_(extensions))
 

--- a/src/kodit/infrastructure/sqlalchemy/snippet_repository.py
+++ b/src/kodit/infrastructure/sqlalchemy/snippet_repository.py
@@ -6,9 +6,9 @@ from pathlib import Path
 from sqlalchemy import delete, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from kodit.domain.entities import File, Snippet, Source
+from kodit.domain.entities import Author, AuthorFileMapping, File, Snippet, Source
 from kodit.domain.repositories import SnippetRepository
-from kodit.domain.value_objects import SnippetListItem
+from kodit.domain.value_objects import MultiSearchRequest, SnippetListItem
 
 
 class SqlAlchemySnippetRepository(SnippetRepository):
@@ -153,3 +153,105 @@ class SqlAlchemySnippetRepository(SnippetRepository):
         except ValueError:
             # If the file is not relative to the source, return the filename
             return Path(file_path).name
+
+    async def search(self, request: MultiSearchRequest) -> Sequence[SnippetListItem]:
+        """Search snippets with filters.
+
+        Args:
+            request: The search request containing queries and optional filters.
+
+        Returns:
+            A sequence of SnippetListItem instances matching the search criteria.
+
+        """
+        # Build the base query with joins
+        query = (
+            select(
+                Snippet,
+                File.cloned_path,
+                Source.cloned_path.label("source_cloned_path"),
+                Source.uri.label("source_uri"),
+            )
+            .join(File, Snippet.file_id == File.id)
+            .join(Source, File.source_id == Source.id)
+        )
+
+        # Apply filters if provided
+        if request.filters:
+            filters = request.filters
+
+            # Language filter (using file extension)
+            if filters.language:
+                # Map common language names to file extensions
+                language_extensions = {
+                    "python": [".py", ".pyw", ".pyx", ".pxd"],
+                    "go": [".go"],
+                    "javascript": [".js", ".jsx", ".mjs"],
+                    "typescript": [".ts", ".tsx"],
+                    "java": [".java"],
+                    "csharp": [".cs"],
+                    "cpp": [".cpp", ".cc", ".cxx", ".hpp", ".h"],
+                    "c": [".c", ".h"],
+                    "rust": [".rs"],
+                    "php": [".php"],
+                    "ruby": [".rb"],
+                    "swift": [".swift"],
+                    "kotlin": [".kt", ".kts"],
+                    "scala": [".scala"],
+                    "r": [".r", ".R"],
+                    "matlab": [".m"],
+                    "perl": [".pl", ".pm"],
+                    "bash": [".sh", ".bash"],
+                    "powershell": [".ps1"],
+                    "sql": [".sql"],
+                    "html": [".html", ".htm"],
+                    "css": [".css", ".scss", ".sass"],
+                    "yaml": [".yml", ".yaml"],
+                    "json": [".json"],
+                    "xml": [".xml"],
+                    "markdown": [".md", ".markdown"],
+                }
+
+                extensions = language_extensions.get(
+                    filters.language.lower(), [f".{filters.language}"]
+                )
+                query = query.where(File.extension.in_(extensions))
+
+            # Author filter
+            if filters.author:
+                query = (
+                    query.join(AuthorFileMapping, File.id == AuthorFileMapping.file_id)
+                    .join(Author, AuthorFileMapping.author_id == Author.id)
+                    .where(Author.name.ilike(f"%{filters.author}%"))
+                )
+
+            # Date filters
+            if filters.created_after:
+                query = query.where(Snippet.created_at >= filters.created_after)
+
+            if filters.created_before:
+                query = query.where(Snippet.created_at <= filters.created_before)
+
+            # Source repository filter
+            if filters.source_repo:
+                query = query.where(Source.uri.like(f"%{filters.source_repo}%"))
+
+        # Apply top_k limit
+        if request.top_k:
+            query = query.limit(request.top_k)
+
+        result = await self.session.execute(query)
+        return [
+            SnippetListItem(
+                id=snippet.id,
+                file_path=self._get_relative_path(file_cloned_path, source_cloned_path),
+                content=snippet.content,
+                source_uri=source_uri_val,
+            )
+            for (
+                snippet,
+                file_cloned_path,
+                source_cloned_path,
+                source_uri_val,
+            ) in result.all()
+        ]

--- a/src/kodit/infrastructure/sqlalchemy/snippet_repository.py
+++ b/src/kodit/infrastructure/sqlalchemy/snippet_repository.py
@@ -8,7 +8,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from kodit.domain.entities import Author, AuthorFileMapping, File, Snippet, Source
 from kodit.domain.repositories import SnippetRepository
-from kodit.domain.value_objects import MultiSearchRequest, SnippetListItem
+from kodit.domain.value_objects import (
+    LanguageMapping,
+    MultiSearchRequest,
+    SnippetListItem,
+)
 
 
 class SqlAlchemySnippetRepository(SnippetRepository):
@@ -182,38 +186,8 @@ class SqlAlchemySnippetRepository(SnippetRepository):
 
             # Language filter (using file extension)
             if filters.language:
-                # Map common language names to file extensions (no leading dot)
-                language_extensions = {
-                    "python": ["py", "pyw", "pyx", "pxd"],
-                    "go": ["go"],
-                    "javascript": ["js", "jsx", "mjs"],
-                    "typescript": ["ts", "tsx"],
-                    "java": ["java"],
-                    "csharp": ["cs"],
-                    "cpp": ["cpp", "cc", "cxx", "hpp", "h"],
-                    "c": ["c", "h"],
-                    "rust": ["rs"],
-                    "php": ["php"],
-                    "ruby": ["rb"],
-                    "swift": ["swift"],
-                    "kotlin": ["kt", "kts"],
-                    "scala": ["scala"],
-                    "r": ["r", "R"],
-                    "matlab": ["m"],
-                    "perl": ["pl", "pm"],
-                    "bash": ["sh", "bash"],
-                    "powershell": ["ps1"],
-                    "sql": ["sql"],
-                    "html": ["html", "htm"],
-                    "css": ["css", "scss", "sass"],
-                    "yaml": ["yml", "yaml"],
-                    "json": ["json"],
-                    "xml": ["xml"],
-                    "markdown": ["md", "markdown"],
-                }
-
-                extensions = language_extensions.get(
-                    filters.language.lower(), [filters.language.lower()]
+                extensions = LanguageMapping.get_extensions_with_fallback(
+                    filters.language
                 )
                 query = query.where(File.extension.in_(extensions))
 

--- a/src/kodit/mcp.py
+++ b/src/kodit/mcp.py
@@ -220,21 +220,13 @@ async def search(  # noqa: PLR0913
     log.debug("Searching for snippets")
 
     # Create filters if any filter parameters are provided
-    filters = None
-    if any([language, author, created_after, created_before, source_repo]):
-        from datetime import datetime
-
-        filters = SnippetSearchFilters(
-            language=language,
-            author=author,
-            created_after=datetime.fromisoformat(created_after)
-            if created_after
-            else None,
-            created_before=datetime.fromisoformat(created_before)
-            if created_before
-            else None,
-            source_repo=source_repo,
-        )
+    filters = SnippetSearchFilters.from_cli_params(
+        language=language,
+        author=author,
+        created_after=created_after,
+        created_before=created_before,
+        source_repo=source_repo,
+    )
 
     search_request = MultiSearchRequest(
         keywords=keywords,

--- a/src/kodit/mcp.py
+++ b/src/kodit/mcp.py
@@ -106,7 +106,7 @@ def create_snippet_application_service(
 
 
 @mcp.tool()
-async def search(
+async def search(  # noqa: PLR0913
     ctx: Context,
     user_intent: Annotated[
         str,
@@ -144,25 +144,35 @@ async def search(
     author: Annotated[
         str | None,
         Field(
-            description="Optional author filter to search for snippets by a specific author."
+            description=(
+                "Optional author filter to search for snippets by a specific author."
+            )
         ),
     ] = None,
     created_after: Annotated[
         str | None,
         Field(
-            description="Optional date filter for snippets created after this date (ISO format: YYYY-MM-DD)."
+            description=(
+                "Optional date filter for snippets created after this date "
+                "(ISO format: YYYY-MM-DD)."
+            )
         ),
     ] = None,
     created_before: Annotated[
         str | None,
         Field(
-            description="Optional date filter for snippets created before this date (ISO format: YYYY-MM-DD)."
+            description=(
+                "Optional date filter for snippets created before this date "
+                "(ISO format: YYYY-MM-DD)."
+            )
         ),
     ] = None,
     source_repo: Annotated[
         str | None,
         Field(
-            description="Optional source repository filter (e.g., 'github.com/example/repo')."
+            description=(
+                "Optional source repository filter (e.g., 'github.com/example/repo')."
+            )
         ),
     ] = None,
 ) -> str:

--- a/tests/kodit/cli_test.py
+++ b/tests/kodit/cli_test.py
@@ -1,12 +1,18 @@
 """Test the CLI."""
 
+import asyncio
+from datetime import datetime, UTC
 from pathlib import Path
 import tempfile
 from typing import Generator
 import pytest
 from click.testing import CliRunner
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine, async_sessionmaker
+from unittest.mock import patch, AsyncMock, MagicMock
 
 from kodit.cli import cli
+from kodit.domain.entities import File, Index, Snippet, Source, SourceType
+from kodit.domain.value_objects import SnippetSearchFilters, MultiSearchRequest
 
 
 @pytest.fixture
@@ -67,3 +73,153 @@ def test_dotenv_file_not_found(runner: CliRunner) -> None:
     result = runner.invoke(cli, ["--env-file", "nonexistent.env", "index"])
     assert result.exit_code == 2
     assert "does not exist" in result.output
+
+
+def test_search_language_filtering_help(runner: CliRunner) -> None:
+    """Test that language filtering options are available in search commands."""
+
+    # Test that language filter option is available in code search
+    result = runner.invoke(cli, ["search", "code", "--help"])
+    assert result.exit_code == 0
+    assert "--language TEXT" in result.output
+    assert "Filter by programming language" in result.output
+
+    # Test that language filter option is available in keyword search
+    result = runner.invoke(cli, ["search", "keyword", "--help"])
+    assert result.exit_code == 0
+    assert "--language TEXT" in result.output
+    assert "Filter by programming language" in result.output
+
+    # Test that language filter option is available in text search
+    result = runner.invoke(cli, ["search", "text", "--help"])
+    assert result.exit_code == 0
+    assert "--language TEXT" in result.output
+    assert "Filter by programming language" in result.output
+
+    # Test that language filter option is available in hybrid search
+    result = runner.invoke(cli, ["search", "hybrid", "--help"])
+    assert result.exit_code == 0
+    assert "--language TEXT" in result.output
+    assert "Filter by programming language" in result.output
+
+
+def test_search_language_filtering_with_mocks(runner: CliRunner) -> None:
+    """Test that language filtering works in search commands using mocks."""
+
+    # Mock the search functionality
+    mock_snippets = [
+        MagicMock(
+            id=1,
+            content="def hello_world():\n    print('Hello from Python!')",
+            file=MagicMock(extension="py"),
+        ),
+        MagicMock(
+            id=2,
+            content="function helloWorld() {\n    console.log('Hello from JavaScript!');\n}",
+            file=MagicMock(extension="js"),
+        ),
+        MagicMock(
+            id=3,
+            content='func helloWorld() {\n    fmt.Println("Hello from Go!")\n}',
+            file=MagicMock(extension="go"),
+        ),
+    ]
+
+    # Mock the indexing application service
+    mock_service = MagicMock()
+    mock_service.search = AsyncMock(return_value=mock_snippets)
+
+    # Mock the snippet application service
+    mock_snippet_service = MagicMock()
+    mock_snippet_service.search = AsyncMock(return_value=mock_snippets)
+
+    with (
+        patch(
+            "kodit.cli.create_indexing_application_service", return_value=mock_service
+        ),
+        patch(
+            "kodit.cli.create_snippet_application_service",
+            return_value=mock_snippet_service,
+        ),
+    ):
+        # Test code search with Python language filter
+        result = runner.invoke(cli, ["search", "code", "hello", "--language", "python"])
+        assert result.exit_code == 0
+
+        # Verify that the search was called with the correct filters
+        mock_service.search.assert_called_once()
+        call_args = mock_service.search.call_args[0][0]
+        assert isinstance(call_args, MultiSearchRequest)
+        assert call_args.code_query == "hello"
+        assert call_args.filters is not None
+        assert call_args.filters.language == "python"
+
+
+def test_search_filters_parsing(runner: CliRunner) -> None:
+    """Test that search filters are properly parsed from CLI arguments."""
+
+    # Mock the search functionality
+    mock_snippets = [MagicMock(id=1, content="test snippet")]
+    mock_service = MagicMock()
+    mock_service.search = AsyncMock(return_value=mock_snippets)
+
+    with patch(
+        "kodit.cli.create_indexing_application_service", return_value=mock_service
+    ):
+        # Test with all filter options
+        result = runner.invoke(
+            cli,
+            [
+                "search",
+                "code",
+                "test query",
+                "--language",
+                "python",
+                "--author",
+                "alice",
+                "--created-after",
+                "2023-01-01",
+                "--created-before",
+                "2023-12-31",
+                "--source-repo",
+                "github.com/example/repo",
+            ],
+        )
+
+        assert result.exit_code == 0
+
+        # Verify that the search was called with the correct filters
+        mock_service.search.assert_called_once()
+        call_args = mock_service.search.call_args[0][0]
+        assert isinstance(call_args, MultiSearchRequest)
+        assert call_args.code_query == "test query"
+        assert call_args.filters is not None
+        assert call_args.filters.language == "python"
+        assert call_args.filters.author == "alice"
+        assert call_args.filters.created_after is not None
+        assert call_args.filters.created_before is not None
+        assert call_args.filters.source_repo == "github.com/example/repo"
+
+
+def test_search_without_filters(runner: CliRunner) -> None:
+    """Test that search works without filters."""
+
+    # Mock the search functionality
+    mock_snippets = [MagicMock(id=1, content="test snippet")]
+    mock_service = MagicMock()
+    mock_service.search = AsyncMock(return_value=mock_snippets)
+
+    with patch(
+        "kodit.cli.create_indexing_application_service", return_value=mock_service
+    ):
+        # Test without any filters
+        result = runner.invoke(cli, ["search", "code", "test query"])
+
+        assert result.exit_code == 0
+
+        # Verify that the search was called without filters
+        mock_service.search.assert_called_once()
+        call_args = mock_service.search.call_args[0][0]
+        assert isinstance(call_args, MultiSearchRequest)
+        assert call_args.code_query == "test query"
+        assert call_args.filters is None

--- a/tests/kodit/cli_test.py
+++ b/tests/kodit/cli_test.py
@@ -223,3 +223,346 @@ def test_search_without_filters(runner: CliRunner) -> None:
         assert isinstance(call_args, MultiSearchRequest)
         assert call_args.code_query == "test query"
         assert call_args.filters is None
+
+
+def test_search_language_filter_all_commands(runner: CliRunner) -> None:
+    """Test language filtering across all search command types."""
+
+    # Mock the search functionality
+    mock_snippets = [MagicMock(id=1, content="test snippet")]
+    mock_service = MagicMock()
+    mock_service.search = AsyncMock(return_value=mock_snippets)
+
+    with patch(
+        "kodit.cli.create_indexing_application_service", return_value=mock_service
+    ):
+        # Test code search with language filter
+        result = runner.invoke(
+            cli, ["search", "code", "test", "--language", "javascript"]
+        )
+        assert result.exit_code == 0
+        call_args = mock_service.search.call_args[0][0]
+        assert call_args.filters.language == "javascript"
+
+        # Reset mock
+        mock_service.search.reset_mock()
+
+        # Test keyword search with language filter
+        result = runner.invoke(
+            cli, ["search", "keyword", "test", "--language", "python"]
+        )
+        assert result.exit_code == 0
+        call_args = mock_service.search.call_args[0][0]
+        assert call_args.filters.language == "python"
+
+        # Reset mock
+        mock_service.search.reset_mock()
+
+        # Test text search with language filter
+        result = runner.invoke(cli, ["search", "text", "test", "--language", "go"])
+        assert result.exit_code == 0
+        call_args = mock_service.search.call_args[0][0]
+        assert call_args.filters.language == "go"
+
+        # Reset mock
+        mock_service.search.reset_mock()
+
+        # Test hybrid search with language filter
+        result = runner.invoke(
+            cli,
+            [
+                "search",
+                "hybrid",
+                "--keywords",
+                "test",
+                "--code",
+                "test",
+                "--text",
+                "test",
+                "--language",
+                "rust",
+            ],
+        )
+        assert result.exit_code == 0
+        call_args = mock_service.search.call_args[0][0]
+        assert call_args.filters.language == "rust"
+
+
+def test_search_author_filter(runner: CliRunner) -> None:
+    """Test author filtering functionality."""
+
+    # Mock the search functionality
+    mock_snippets = [MagicMock(id=1, content="test snippet")]
+    mock_service = MagicMock()
+    mock_service.search = AsyncMock(return_value=mock_snippets)
+
+    with patch(
+        "kodit.cli.create_indexing_application_service", return_value=mock_service
+    ):
+        # Test with author filter
+        result = runner.invoke(cli, ["search", "code", "test", "--author", "john.doe"])
+        assert result.exit_code == 0
+
+        # Verify that the search was called with the correct author filter
+        mock_service.search.assert_called_once()
+        call_args = mock_service.search.call_args[0][0]
+        assert call_args.filters.author == "john.doe"
+
+        # Test with author filter containing spaces
+        mock_service.search.reset_mock()
+        result = runner.invoke(cli, ["search", "code", "test", "--author", "John Doe"])
+        assert result.exit_code == 0
+        call_args = mock_service.search.call_args[0][0]
+        assert call_args.filters.author == "John Doe"
+
+
+def test_search_created_after_filter(runner: CliRunner) -> None:
+    """Test created-after date filtering functionality."""
+
+    # Mock the search functionality
+    mock_snippets = [MagicMock(id=1, content="test snippet")]
+    mock_service = MagicMock()
+    mock_service.search = AsyncMock(return_value=mock_snippets)
+
+    with patch(
+        "kodit.cli.create_indexing_application_service", return_value=mock_service
+    ):
+        # Test with created-after filter
+        result = runner.invoke(
+            cli, ["search", "code", "test", "--created-after", "2023-06-15"]
+        )
+        assert result.exit_code == 0
+
+        # Verify that the search was called with the correct date filter
+        mock_service.search.assert_called_once()
+        call_args = mock_service.search.call_args[0][0]
+        assert call_args.filters.created_after is not None
+        # The date should be parsed correctly
+        assert call_args.filters.created_after.year == 2023
+        assert call_args.filters.created_after.month == 6
+        assert call_args.filters.created_after.day == 15
+
+
+def test_search_created_before_filter(runner: CliRunner) -> None:
+    """Test created-before date filtering functionality."""
+
+    # Mock the search functionality
+    mock_snippets = [MagicMock(id=1, content="test snippet")]
+    mock_service = MagicMock()
+    mock_service.search = AsyncMock(return_value=mock_snippets)
+
+    with patch(
+        "kodit.cli.create_indexing_application_service", return_value=mock_service
+    ):
+        # Test with created-before filter
+        result = runner.invoke(
+            cli, ["search", "code", "test", "--created-before", "2024-01-31"]
+        )
+        assert result.exit_code == 0
+
+        # Verify that the search was called with the correct date filter
+        mock_service.search.assert_called_once()
+        call_args = mock_service.search.call_args[0][0]
+        assert call_args.filters.created_before is not None
+        # The date should be parsed correctly
+        assert call_args.filters.created_before.year == 2024
+        assert call_args.filters.created_before.month == 1
+        assert call_args.filters.created_before.day == 31
+
+
+def test_search_source_repo_filter(runner: CliRunner) -> None:
+    """Test source repository filtering functionality."""
+
+    # Mock the search functionality
+    mock_snippets = [MagicMock(id=1, content="test snippet")]
+    mock_service = MagicMock()
+    mock_service.search = AsyncMock(return_value=mock_snippets)
+
+    with patch(
+        "kodit.cli.create_indexing_application_service", return_value=mock_service
+    ):
+        # Test with source-repo filter
+        result = runner.invoke(
+            cli,
+            ["search", "code", "test", "--source-repo", "github.com/example/project"],
+        )
+        assert result.exit_code == 0
+
+        # Verify that the search was called with the correct source repo filter
+        mock_service.search.assert_called_once()
+        call_args = mock_service.search.call_args[0][0]
+        assert call_args.filters.source_repo == "github.com/example/project"
+
+        # Test with different source repo format
+        mock_service.search.reset_mock()
+        result = runner.invoke(
+            cli, ["search", "code", "test", "--source-repo", "gitlab.com/team/repo"]
+        )
+        assert result.exit_code == 0
+        call_args = mock_service.search.call_args[0][0]
+        assert call_args.filters.source_repo == "gitlab.com/team/repo"
+
+
+def test_search_multiple_filters_combination(runner: CliRunner) -> None:
+    """Test combinations of multiple filters."""
+
+    # Mock the search functionality
+    mock_snippets = [MagicMock(id=1, content="test snippet")]
+    mock_service = MagicMock()
+    mock_service.search = AsyncMock(return_value=mock_snippets)
+
+    with patch(
+        "kodit.cli.create_indexing_application_service", return_value=mock_service
+    ):
+        # Test language + author combination
+        result = runner.invoke(
+            cli, ["search", "code", "test", "--language", "python", "--author", "alice"]
+        )
+        assert result.exit_code == 0
+        call_args = mock_service.search.call_args[0][0]
+        assert call_args.filters.language == "python"
+        assert call_args.filters.author == "alice"
+
+        # Reset mock
+        mock_service.search.reset_mock()
+
+        # Test language + date range combination
+        result = runner.invoke(
+            cli,
+            [
+                "search",
+                "code",
+                "test",
+                "--language",
+                "javascript",
+                "--created-after",
+                "2023-01-01",
+                "--created-before",
+                "2023-12-31",
+            ],
+        )
+        assert result.exit_code == 0
+        call_args = mock_service.search.call_args[0][0]
+        assert call_args.filters.language == "javascript"
+        assert call_args.filters.created_after is not None
+        assert call_args.filters.created_before is not None
+
+        # Reset mock
+        mock_service.search.reset_mock()
+
+        # Test author + source repo combination
+        result = runner.invoke(
+            cli,
+            [
+                "search",
+                "code",
+                "test",
+                "--author",
+                "bob",
+                "--source-repo",
+                "github.com/company/project",
+            ],
+        )
+        assert result.exit_code == 0
+        call_args = mock_service.search.call_args[0][0]
+        assert call_args.filters.author == "bob"
+        assert call_args.filters.source_repo == "github.com/company/project"
+
+
+def test_search_invalid_date_format(runner: CliRunner) -> None:
+    """Test that invalid date formats are handled gracefully."""
+
+    # Mock the search functionality
+    mock_snippets = [MagicMock(id=1, content="test snippet")]
+    mock_service = MagicMock()
+    mock_service.search = AsyncMock(return_value=mock_snippets)
+
+    with patch(
+        "kodit.cli.create_indexing_application_service", return_value=mock_service
+    ):
+        # Test with invalid date format
+        result = runner.invoke(
+            cli, ["search", "code", "test", "--created-after", "invalid-date"]
+        )
+        assert result.exit_code == 1  # Should fail with ValueError
+        assert isinstance(result.exception, ValueError)
+        assert "Invalid isoformat string" in str(result.exception)
+
+        # Test with invalid date format for created-before
+        result = runner.invoke(
+            cli, ["search", "code", "test", "--created-before", "not-a-date"]
+        )
+        assert result.exit_code == 1  # Should fail with ValueError
+        assert isinstance(result.exception, ValueError)
+        assert "Invalid isoformat string" in str(result.exception)
+
+
+def test_search_filter_case_insensitivity(runner: CliRunner) -> None:
+    """Test that language filters are case insensitive."""
+
+    # Mock the search functionality
+    mock_snippets = [MagicMock(id=1, content="test snippet")]
+    mock_service = MagicMock()
+    mock_service.search = AsyncMock(return_value=mock_snippets)
+
+    with patch(
+        "kodit.cli.create_indexing_application_service", return_value=mock_service
+    ):
+        # Test with uppercase language
+        result = runner.invoke(cli, ["search", "code", "test", "--language", "PYTHON"])
+        assert result.exit_code == 0
+        call_args = mock_service.search.call_args[0][0]
+        assert call_args.filters.language == "PYTHON"  # Should preserve case for now
+
+        # Reset mock
+        mock_service.search.reset_mock()
+
+        # Test with mixed case language
+        result = runner.invoke(
+            cli, ["search", "code", "test", "--language", "JavaScript"]
+        )
+        assert result.exit_code == 0
+        call_args = mock_service.search.call_args[0][0]
+        assert (
+            call_args.filters.language == "JavaScript"
+        )  # Should preserve case for now
+
+
+def test_search_filter_help_text(runner: CliRunner) -> None:
+    """Test that all filter options show up in help text."""
+
+    # Test code search help
+    result = runner.invoke(cli, ["search", "code", "--help"])
+    assert result.exit_code == 0
+    assert "--language TEXT" in result.output
+    assert "--author TEXT" in result.output
+    assert "--created-after TEXT" in result.output
+    assert "--created-before TEXT" in result.output
+    assert "--source-repo TEXT" in result.output
+
+    # Test keyword search help
+    result = runner.invoke(cli, ["search", "keyword", "--help"])
+    assert result.exit_code == 0
+    assert "--language TEXT" in result.output
+    assert "--author TEXT" in result.output
+    assert "--created-after TEXT" in result.output
+    assert "--created-before TEXT" in result.output
+    assert "--source-repo TEXT" in result.output
+
+    # Test text search help
+    result = runner.invoke(cli, ["search", "text", "--help"])
+    assert result.exit_code == 0
+    assert "--language TEXT" in result.output
+    assert "--author TEXT" in result.output
+    assert "--created-after TEXT" in result.output
+    assert "--created-before TEXT" in result.output
+    assert "--source-repo TEXT" in result.output
+
+    # Test hybrid search help
+    result = runner.invoke(cli, ["search", "hybrid", "--help"])
+    assert result.exit_code == 0
+    assert "--language TEXT" in result.output
+    assert "--author TEXT" in result.output
+    assert "--created-after TEXT" in result.output
+    assert "--created-before TEXT" in result.output
+    assert "--source-repo TEXT" in result.output

--- a/tests/kodit/cli_test.py
+++ b/tests/kodit/cli_test.py
@@ -486,7 +486,7 @@ def test_search_invalid_date_format(runner: CliRunner) -> None:
         )
         assert result.exit_code == 1  # Should fail with ValueError
         assert isinstance(result.exception, ValueError)
-        assert "Invalid isoformat string" in str(result.exception)
+        assert "Invalid date format for created_after" in str(result.exception)
 
         # Test with invalid date format for created-before
         result = runner.invoke(
@@ -494,7 +494,7 @@ def test_search_invalid_date_format(runner: CliRunner) -> None:
         )
         assert result.exit_code == 1  # Should fail with ValueError
         assert isinstance(result.exception, ValueError)
-        assert "Invalid isoformat string" in str(result.exception)
+        assert "Invalid date format for created_before" in str(result.exception)
 
 
 def test_search_filter_case_insensitivity(runner: CliRunner) -> None:

--- a/tests/kodit/domain/test_language_mapping.py
+++ b/tests/kodit/domain/test_language_mapping.py
@@ -1,0 +1,125 @@
+"""Tests for LanguageMapping value object."""
+
+import pytest
+
+from kodit.domain.value_objects import LanguageMapping
+
+
+class TestLanguageMapping:
+    """Test cases for LanguageMapping value object."""
+
+    def test_get_extensions_for_language_python(self):
+        """Test getting extensions for Python."""
+        extensions = LanguageMapping.get_extensions_for_language("python")
+        assert extensions == ["py", "pyw", "pyx", "pxd"]
+
+    def test_get_extensions_for_language_javascript(self):
+        """Test getting extensions for JavaScript."""
+        extensions = LanguageMapping.get_extensions_for_language("javascript")
+        assert extensions == ["js", "jsx", "mjs"]
+
+    def test_get_extensions_for_language_case_insensitive(self):
+        """Test that language names are case insensitive."""
+        extensions = LanguageMapping.get_extensions_for_language("PYTHON")
+        assert extensions == ["py", "pyw", "pyx", "pxd"]
+
+    def test_get_extensions_for_unsupported_language(self):
+        """Test that unsupported languages raise ValueError."""
+        with pytest.raises(ValueError, match="Unsupported language: unsupported"):
+            LanguageMapping.get_extensions_for_language("unsupported")
+
+    def test_get_language_for_extension_py(self):
+        """Test getting language for .py extension."""
+        language = LanguageMapping.get_language_for_extension("py")
+        assert language == "python"
+
+    def test_get_language_for_extension_with_dot(self):
+        """Test getting language for extension with leading dot."""
+        language = LanguageMapping.get_language_for_extension(".py")
+        assert language == "python"
+
+    def test_get_language_for_extension_case_insensitive(self):
+        """Test that extensions are case insensitive."""
+        language = LanguageMapping.get_language_for_extension("PY")
+        assert language == "python"
+
+    def test_get_language_for_unsupported_extension(self):
+        """Test that unsupported extensions raise ValueError."""
+        with pytest.raises(ValueError, match="Unsupported file extension: unsupported"):
+            LanguageMapping.get_language_for_extension("unsupported")
+
+    def test_get_extension_to_language_map(self):
+        """Test getting the extension to language mapping."""
+        extension_map = LanguageMapping.get_extension_to_language_map()
+
+        # Check a few key mappings
+        assert extension_map["py"] == "python"
+        assert extension_map["js"] == "javascript"
+        assert extension_map["go"] == "go"
+
+        # Check that all extensions are included
+        assert "py" in extension_map
+        assert "js" in extension_map
+        assert "ts" in extension_map
+
+    def test_get_supported_languages(self):
+        """Test getting list of supported languages."""
+        languages = LanguageMapping.get_supported_languages()
+
+        # Check that key languages are included
+        assert "python" in languages
+        assert "javascript" in languages
+        assert "go" in languages
+        assert "rust" in languages
+
+    def test_get_supported_extensions(self):
+        """Test getting list of supported extensions."""
+        extensions = LanguageMapping.get_supported_extensions()
+
+        # Check that key extensions are included
+        assert "py" in extensions
+        assert "js" in extensions
+        assert "go" in extensions
+        assert "rs" in extensions
+
+    def test_is_supported_language(self):
+        """Test checking if a language is supported."""
+        assert LanguageMapping.is_supported_language("python") is True
+        assert LanguageMapping.is_supported_language("PYTHON") is True
+        assert LanguageMapping.is_supported_language("unsupported") is False
+
+    def test_is_supported_extension(self):
+        """Test checking if an extension is supported."""
+        assert LanguageMapping.is_supported_extension("py") is True
+        assert LanguageMapping.is_supported_extension(".py") is True
+        assert LanguageMapping.is_supported_extension("PY") is True
+        assert LanguageMapping.is_supported_extension("unsupported") is False
+
+    def test_bidirectional_mapping_consistency(self):
+        """Test that bidirectional mapping is consistent."""
+        # Test that extension -> language -> extension gives the same result
+        for language in LanguageMapping.get_supported_languages():
+            extensions = LanguageMapping.get_extensions_for_language(language)
+            for extension in extensions:
+                detected_language = LanguageMapping.get_language_for_extension(
+                    extension
+                )
+                assert detected_language == language
+
+    def test_extension_uniqueness(self):
+        """Test that each extension maps to only one language."""
+        extension_map = LanguageMapping.get_extension_to_language_map()
+        extension_values = list(extension_map.values())
+
+        # Check that there are no duplicate extensions
+        assert len(extension_map) == len(set(extension_map.keys()))
+
+    def test_get_extensions_with_fallback_supported_language(self):
+        """Test fallback method returns extensions for supported language."""
+        extensions = LanguageMapping.get_extensions_with_fallback("python")
+        assert extensions == ["py", "pyw", "pyx", "pxd"]
+
+    def test_get_extensions_with_fallback_unsupported_language(self):
+        """Test fallback method returns [language.lower()] for unsupported language."""
+        extensions = LanguageMapping.get_extensions_with_fallback("foobar")
+        assert extensions == ["foobar"]

--- a/tests/kodit/domain/test_models.py
+++ b/tests/kodit/domain/test_models.py
@@ -21,6 +21,7 @@ from kodit.domain.value_objects import (
     VectorSearchResult,
     EnrichmentRequest,
     EnrichmentResponse,
+    SnippetSearchFilters,
 )
 
 
@@ -158,3 +159,28 @@ class TestEnrichmentModels:
         response = EnrichmentResponse(snippet_id=1, text="enriched content")
         assert response.snippet_id == 1
         assert response.text == "enriched content"
+
+
+class TestSnippetSearchFilters:
+    """Test SnippetSearchFilters value object."""
+
+    def test_create_filters(self):
+        filters = SnippetSearchFilters(
+            language="python",
+            author="alice",
+            created_after=datetime(2023, 1, 1),
+            created_before=datetime(2023, 12, 31),
+            source_repo="github.com/example/repo",
+        )
+        assert filters.language == "python"
+        assert filters.author == "alice"
+        assert filters.created_after == datetime(2023, 1, 1)
+        assert filters.created_before == datetime(2023, 12, 31)
+        assert filters.source_repo == "github.com/example/repo"
+
+    def test_equality(self):
+        f1 = SnippetSearchFilters(language="python", author="alice")
+        f2 = SnippetSearchFilters(language="python", author="alice")
+        f3 = SnippetSearchFilters(language="go", author="bob")
+        assert f1 == f2
+        assert f1 != f3

--- a/tests/kodit/domain/test_models.py
+++ b/tests/kodit/domain/test_models.py
@@ -59,11 +59,12 @@ class TestFile:
             created_at=now,
             updated_at=now,
             source_id=1,
-            cloned_path="/tmp/test.txt",
             mime_type="text/plain",
             uri="file:///test.txt",
+            cloned_path="/tmp/test.txt",
             sha256="abc123",
             size_bytes=100,
+            extension="txt",
         )
 
         assert file.source_id == 1
@@ -72,6 +73,7 @@ class TestFile:
         assert file.cloned_path == "/tmp/test.txt"
         assert file.sha256 == "abc123"
         assert file.size_bytes == 100
+        assert file.extension == "txt"
 
 
 class TestSnippet:

--- a/tests/kodit/domain/test_models.py
+++ b/tests/kodit/domain/test_models.py
@@ -22,6 +22,7 @@ from kodit.domain.value_objects import (
     EnrichmentRequest,
     EnrichmentResponse,
     SnippetSearchFilters,
+    MultiSearchRequest,
 )
 
 
@@ -184,3 +185,16 @@ class TestSnippetSearchFilters:
         f3 = SnippetSearchFilters(language="go", author="bob")
         assert f1 == f2
         assert f1 != f3
+
+    def test_multi_search_request_with_filters(self):
+        filters = SnippetSearchFilters(language="python", author="alice")
+        request = MultiSearchRequest(
+            text_query="test query",
+            code_query="def test(): pass",
+            keywords=["test", "python"],
+            filters=filters,
+        )
+        assert request.text_query == "test query"
+        assert request.code_query == "def test(): pass"
+        assert request.keywords == ["test", "python"]
+        assert request.filters == filters

--- a/tests/kodit/infrastructure/embedding/test_embedding_integration.py
+++ b/tests/kodit/infrastructure/embedding/test_embedding_integration.py
@@ -68,9 +68,12 @@ class TestEmbeddingIntegration:
             created_at=datetime.now(UTC),
             updated_at=datetime.now(UTC),
             source_id=source.id,
-            cloned_path="/tmp/test_repo/test.py",
             mime_type="text/plain",
             uri="test.py",
+            cloned_path="/tmp/test_repo/test.py",
+            sha256="abc123",
+            size_bytes=100,
+            extension="py",
         )
         session.add(file)
         await session.commit()
@@ -171,9 +174,12 @@ class TestEmbeddingIntegration:
             created_at=datetime.now(UTC),
             updated_at=datetime.now(UTC),
             source_id=source.id,
-            cloned_path="/tmp/test_repo/test.py",
             mime_type="text/plain",
             uri="test.py",
+            cloned_path="/tmp/test_repo/test.py",
+            sha256="abc123",
+            size_bytes=100,
+            extension="py",
         )
         session.add(file)
         await session.commit()
@@ -269,9 +275,12 @@ class TestEmbeddingIntegration:
             created_at=datetime.now(UTC),
             updated_at=datetime.now(UTC),
             source_id=source.id,
-            cloned_path="/tmp/test_repo/test.py",
             mime_type="text/plain",
             uri="test.py",
+            cloned_path="/tmp/test_repo/test.py",
+            sha256="abc123",
+            size_bytes=100,
+            extension="py",
         )
         session.add(file)
         await session.commit()
@@ -369,9 +378,12 @@ class TestEmbeddingIntegration:
             created_at=datetime.now(UTC),
             updated_at=datetime.now(UTC),
             source_id=source.id,
-            cloned_path="/tmp/test_repo/test.py",
             mime_type="text/plain",
             uri="test.py",
+            cloned_path="/tmp/test_repo/test.py",
+            sha256="abc123",
+            size_bytes=100,
+            extension="py",
         )
         session.add(file)
         await session.commit()
@@ -460,9 +472,12 @@ class TestEmbeddingIntegration:
             created_at=datetime.now(UTC),
             updated_at=datetime.now(UTC),
             source_id=source.id,
-            cloned_path="/tmp/test_repo/test.py",
             mime_type="text/plain",
             uri="test.py",
+            cloned_path="/tmp/test_repo/test.py",
+            sha256="abc123",
+            size_bytes=100,
+            extension="py",
         )
         session.add(file)
         await session.commit()
@@ -540,9 +555,12 @@ class TestEmbeddingIntegration:
             created_at=datetime.now(UTC),
             updated_at=datetime.now(UTC),
             source_id=source.id,
-            cloned_path="/tmp/test_repo/test.py",
             mime_type="text/plain",
             uri="test.py",
+            cloned_path="/tmp/test_repo/test.py",
+            sha256="abc123",
+            size_bytes=100,
+            extension="py",
         )
         session.add(file)
         await session.commit()

--- a/tests/kodit/infrastructure/embedding/test_local_vector_search_repository.py
+++ b/tests/kodit/infrastructure/embedding/test_local_vector_search_repository.py
@@ -305,9 +305,12 @@ async def test_retrieve_documents(session):
         created_at=datetime.now(UTC),
         updated_at=datetime.now(UTC),
         source_id=source.id,
-        cloned_path="/tmp/test_repo/test.py",
         mime_type="text/plain",
         uri="test.py",
+        cloned_path="/tmp/test_repo/test.py",
+        sha256="abc123",
+        size_bytes=100,
+        extension="py",
     )
     session.add(file)
     await session.commit()

--- a/tests/kodit/infrastructure/indexing/indexing_repository_test.py
+++ b/tests/kodit/infrastructure/indexing/indexing_repository_test.py
@@ -26,7 +26,12 @@ async def test_should_allow_multiple_snippets_for_one_file(
         created_at=datetime.now(UTC),
         updated_at=datetime.now(UTC),
         source_id=source.id,
+        mime_type="text/plain",
+        uri="test.py",
         cloned_path="test.py",
+        sha256="abc123",
+        size_bytes=100,
+        extension="py",
     )
     session.add(file)
     await session.commit()
@@ -78,7 +83,12 @@ async def test_should_return_when_items_are_present(
         created_at=datetime.now(UTC),
         updated_at=datetime.now(UTC),
         source_id=source.id,
+        mime_type="text/plain",
+        uri="test.py",
         cloned_path="test.py",
+        sha256="abc123",
+        size_bytes=100,
+        extension="py",
     )
     session.add(file)
     await session.commit()

--- a/tests/kodit/infrastructure/sqlalchemy/test_snippet_repository.py
+++ b/tests/kodit/infrastructure/sqlalchemy/test_snippet_repository.py
@@ -32,9 +32,12 @@ async def test_list_snippets_by_file_path(session: AsyncSession):
         created_at=datetime.now(UTC),
         updated_at=datetime.now(UTC),
         source_id=source.id,
-        cloned_path="/tmp/test_repo/test.py",
         mime_type="text/plain",
         uri="test.py",
+        cloned_path="/tmp/test_repo/test.py",
+        sha256="abc123",
+        size_bytes=100,
+        extension="py",
     )
     session.add(file)
     await session.commit()
@@ -90,17 +93,23 @@ async def test_list_snippets_by_source_uri(session: AsyncSession):
         created_at=datetime.now(UTC),
         updated_at=datetime.now(UTC),
         source_id=source1.id,
-        cloned_path="/tmp/test_repo1/file1.py",
         mime_type="text/plain",
         uri="file1.py",
+        cloned_path="/tmp/test_repo1/file1.py",
+        sha256="abc123",
+        size_bytes=100,
+        extension="py",
     )
     file2 = File(
         created_at=datetime.now(UTC),
         updated_at=datetime.now(UTC),
         source_id=source2.id,
-        cloned_path="/tmp/test_repo2/file2.py",
         mime_type="text/plain",
         uri="file2.py",
+        cloned_path="/tmp/test_repo2/file2.py",
+        sha256="abc123",
+        size_bytes=100,
+        extension="py",
     )
     session.add(file1)
     session.add(file2)
@@ -152,17 +161,23 @@ async def test_list_snippets_by_directory_path(session: AsyncSession):
         created_at=datetime.now(UTC),
         updated_at=datetime.now(UTC),
         source_id=source.id,
-        cloned_path="/tmp/test_repo/file1.py",
         mime_type="text/plain",
         uri="file1.py",
+        cloned_path="/tmp/test_repo/file1.py",
+        sha256="abc123",
+        size_bytes=100,
+        extension="py",
     )
     file2 = File(
         created_at=datetime.now(UTC),
         updated_at=datetime.now(UTC),
         source_id=source.id,
-        cloned_path="/tmp/test_repo/file2.py",
         mime_type="text/plain",
         uri="file2.py",
+        cloned_path="/tmp/test_repo/file2.py",
+        sha256="abc123",
+        size_bytes=100,
+        extension="py",
     )
     session.add(file1)
     session.add(file2)
@@ -213,9 +228,12 @@ async def test_list_snippets_no_filter(session: AsyncSession):
         created_at=datetime.now(UTC),
         updated_at=datetime.now(UTC),
         source_id=source.id,
-        cloned_path="/tmp/test_repo/test.py",
         mime_type="text/plain",
         uri="test.py",
+        cloned_path="/tmp/test_repo/test.py",
+        sha256="abc123",
+        size_bytes=100,
+        extension="py",
     )
     session.add(file)
     await session.commit()
@@ -262,9 +280,12 @@ async def test_list_snippets_no_results(session: AsyncSession):
         created_at=datetime.now(UTC),
         updated_at=datetime.now(UTC),
         source_id=source.id,
-        cloned_path="/tmp/test_repo/test.py",
         mime_type="text/plain",
         uri="test.py",
+        cloned_path="/tmp/test_repo/test.py",
+        sha256="abc123",
+        size_bytes=100,
+        extension="py",
     )
     session.add(file)
     await session.commit()
@@ -303,9 +324,12 @@ async def test_list_snippets_by_relative_path(session: AsyncSession):
         created_at=datetime.now(UTC),
         updated_at=datetime.now(UTC),
         source_id=source.id,
-        cloned_path="/tmp/test_repo/domain/Beer.js",
         mime_type="text/plain",
         uri="domain/Beer.js",
+        cloned_path="/tmp/test_repo/domain/Beer.js",
+        sha256="abc123",
+        size_bytes=100,
+        extension="js",
     )
     session.add(file)
     await session.commit()


### PR DESCRIPTION
Initial implementation of filters in search queries. Use the CLI or MCP server to filter results by:
- source
- language
- creation date
- author