### PR TITLE
fix(db): chunk large IN queries to avoid PostgreSQL parameter limits

### DIFF
--- a/src/kodit/infrastructure/sqlalchemy/query.py
+++ b/src/kodit/infrastructure/sqlalchemy/query.py
@@ -159,6 +159,29 @@ class QueryBuilder(Query):
 
         return stmt
 
+    def get_large_in_filters(self, chunk_size: int) -> list[FilterCriteria]:
+        """Get filters that have IN clauses larger than chunk_size."""
+        return [
+            f
+            for f in self._filters
+            if f.operator == FilterOperator.IN
+            and isinstance(f.value, list)
+            and len(f.value) > chunk_size
+        ]
+
+    def with_replaced_filter(
+        self, old_filter: FilterCriteria, new_filter: FilterCriteria
+    ) -> Self:
+        """Create a copy of this query with a filter replaced."""
+        new_query = self.__class__()
+        # Copy internal state - accessing private members is intentional for cloning
+        new_query._filters = [  # noqa: SLF001
+            new_filter if f == old_filter else f for f in self._filters
+        ]
+        new_query._sorts = self._sorts.copy()  # noqa: SLF001
+        new_query._pagination = self._pagination  # noqa: SLF001
+        return new_query  # type: ignore[return-value]
+
 
 class EnrichmentAssociationQueryBuilder(QueryBuilder):
     """Query builder for enrichment association entities."""

--- a/src/kodit/infrastructure/sqlalchemy/task_repository.py
+++ b/src/kodit/infrastructure/sqlalchemy/task_repository.py
@@ -32,7 +32,7 @@ class SqlAlchemyTaskRepository(
 
     def __init__(self, session_factory: Callable[[], AsyncSession]) -> None:
         """Initialize the repository."""
-        self.session_factory = session_factory
+        super().__init__(session_factory)
         self.log = structlog.get_logger(__name__)
 
     @property


### PR DESCRIPTION
## Summary
Fixes PostgreSQL parameter limit error that occurs when querying large numbers of enrichments.

## Problem
In production, we encountered this error:
```
(sqlalchemy.dialects.postgresql.asyncpg.InterfaceError) <class 'asyncpg.exceptions._base.InterfaceError'>: 
the number of query arguments cannot exceed 32767
[SQL: SELECT enrichments_v2.type, enrichments_v2.subtype, enrichments_v2.content, enrichments_v2.id, 
enrichments_v2.created_at, enrichments_v2.updated_at 
FROM enrichments_v2 
WHERE enrichments_v2.id IN ($3::INTEGER, $4::INTEGER, ...
```

This occurred when `get_all_snippets_for_commit` was called with more than 32,767 enrichment IDs, creating an `IN` clause that exceeded PostgreSQL's parameter limit.

## Solution
Implemented automatic chunking for large `IN` queries at the repository layer:

- `SqlAlchemyRepository.find()` now detects `IN` filters with >1000 values
- Automatically splits them into multiple queries of 1000 values each
- Combines results transparently
- Preserves all other filters, sorting, and pagination

## Changes
- **src/kodit/infrastructure/sqlalchemy/query.py**:
  - Added `get_large_in_filters()` to detect large `IN` clauses
  - Added `with_replaced_filter()` to create query copies with modified filters

- **src/kodit/infrastructure/sqlalchemy/repository.py**:
  - Modified `find()` to detect and chunk large `IN` queries
  - Added `_find_with_chunked_in()` for chunked execution

- **src/kodit/infrastructure/sqlalchemy/task_repository.py**:
  - Fixed `__init__` to call `super().__init__()` to properly initialize `_chunk_size`

- **tests/kodit/infrastructure/sqlalchemy/repository_test.py**:
  - Added `test_chunks_large_in_queries` (tests with 2500 entities)
  - Added `test_chunks_preserves_other_filters` (verifies filter preservation)

## Test Results
- All 303 tests pass
- Repository coverage: 94%
- New tests verify chunking with 2500 entities (2.5x the chunk size)

## Notes
- The fix is transparent to existing code - no changes needed to callers
- Chunk size is set to 1000 (well below PostgreSQL's 32,767 limit)
- Works with all repository types that inherit from `SqlAlchemyRepository`