### PR TITLE
fix(indexing): pull on every sync

### DIFF
--- a/docs/reference/api/index.md
+++ b/docs/reference/api/index.md
@@ -12,7 +12,7 @@ look at the [hosted version](https://kodit.helix.ml/docs).
 This is the REST API for the Kodit server. Please refer to the
 [Kodit documentation](https://docs.helix.ml/kodit/) for more information.
     
-Current version: 0.5.8
+Current version: 0.5.9
 
 ## Authentication
 

--- a/docs/reference/api/openapi.json
+++ b/docs/reference/api/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "kodit API",
     "description": "\nThis is the REST API for the Kodit server. Please refer to the\n[Kodit documentation](https://docs.helix.ml/kodit/) for more information.\n    ",
-    "version": "0.5.8"
+    "version": "0.5.9"
   },
   "paths": {
     "/healthz": {


### PR DESCRIPTION
The sync process was scanning repositories without first pulling the latest changes from the remote. This caused the sync to always detect the same stale commits and never index new commits that were pushed to the remote repository.