### PR TITLE
fix(API): null timestamps in list repositories endpoint

### DIFF
--- a/src/kodit/infrastructure/sqlalchemy/git_repository.py
+++ b/src/kodit/infrastructure/sqlalchemy/git_repository.py
@@ -70,6 +70,8 @@ class SqlAlchemyGitRepoRepository(
 
         return GitRepo(
             id=db_entity.id,
+            created_at=db_entity.created_at,
+            updated_at=db_entity.updated_at,
             sanitized_remote_uri=AnyUrl(db_entity.sanitized_remote_uri),
             remote_uri=AnyUrl(db_entity.remote_uri),
             cloned_path=db_entity.cloned_path,


### PR DESCRIPTION
The to_domain method in SqlAlchemyGitRepoRepository was not mapping the created_at and updated_at fields from the database entity to the domain entity, causing these timestamps to always appear as null in the API response.

## Description
<!-- Please provide a brief description of the changes in this PR -->

## Related Issue
<!-- If this PR fixes an issue, please link it here using the format: Fixes #123 -->

## Type of Change
<!-- Please check the relevant boxes with [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe)

## Checklist:
<!-- Please check the relevant boxes with [x] -->

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional Notes
<!-- Add any additional notes about the PR here --> 