### PR TITLE
fix(enrichments): commit truncation for large diffs

### DIFF
--- a/src/kodit/application/handlers/commit/commit_description.py
+++ b/src/kodit/application/handlers/commit/commit_description.py
@@ -24,6 +24,18 @@ if TYPE_CHECKING:
         EnrichmentQueryService,
     )
 
+# Maximum characters for a commit diff before truncation (roughly ~25k tokens)
+MAX_DIFF_LENGTH = 100_000
+
+
+def truncate_diff(diff: str, max_length: int = MAX_DIFF_LENGTH) -> str:
+    """Truncate a diff to a reasonable length for LLM processing."""
+    if len(diff) <= max_length:
+        return diff
+    truncation_notice = "\n\n[diff truncated due to size]"
+    return diff[: max_length - len(truncation_notice)] + truncation_notice
+
+
 COMMIT_DESCRIPTION_SYSTEM_PROMPT = """
 You are a professional software developer. You will be given a git commit diff.
 Please provide a concise description of what changes were made and why.
@@ -91,7 +103,7 @@ class CommitDescriptionHandler:
             # Enrich the diff through the enricher
             enrichment_request = GenericEnrichmentRequest(
                 id=commit_sha,
-                text=diff,
+                text=truncate_diff(diff),
                 system_prompt=COMMIT_DESCRIPTION_SYSTEM_PROMPT,
             )
 

--- a/tests/kodit/application/handlers/commit/__init__.py
+++ b/tests/kodit/application/handlers/commit/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for commit handlers."""

--- a/tests/kodit/application/handlers/commit/test_commit_description.py
+++ b/tests/kodit/application/handlers/commit/test_commit_description.py
@@ -1,0 +1,23 @@
+"""Tests for commit description handler."""
+
+from kodit.application.handlers.commit.commit_description import truncate_diff
+
+
+def test_truncate_diff_truncates_large_diffs() -> None:
+    """Test that large diffs get truncated."""
+    # Create a diff larger than the max length (100k chars)
+    large_diff = "a" * 150_000
+
+    result = truncate_diff(large_diff)
+
+    assert len(result) <= 100_000
+    assert result.endswith("\n\n[diff truncated due to size]")
+
+
+def test_truncate_diff_preserves_small_diffs() -> None:
+    """Test that small diffs are not truncated."""
+    small_diff = "small diff content"
+
+    result = truncate_diff(small_diff)
+
+    assert result == small_diff


### PR DESCRIPTION
Large commit diffs could exceed LLM context windows when generating commit descriptions. Added truncate_diff() to cap diffs at 100k chars.