### PR TITLE
fix: handle single-commit repos in get_commit_diff

### DIFF
--- a/src/kodit/infrastructure/cloning/git/dulwich_adaptor.py
+++ b/src/kodit/infrastructure/cloning/git/dulwich_adaptor.py
@@ -616,11 +616,13 @@ class DulwichAdapter:
             output = io.BytesIO()
             if not commit.parents:
                 # For first commit, diff against empty tree
+                # We must add the empty tree to the object store so dulwich can find it
                 empty_tree = Tree()
+                repo.object_store.add_object(empty_tree)
                 porcelain.diff_tree(
                     repo,
-                    empty_tree,
-                    commit_bytes,
+                    empty_tree.id,
+                    commit.tree,
                     outstream=output,
                 )
             else:

--- a/src/kodit/infrastructure/cloning/git/git_python_adaptor.py
+++ b/src/kodit/infrastructure/cloning/git/git_python_adaptor.py
@@ -10,7 +10,7 @@ from typing import Any
 
 import structlog
 
-from git import Blob, GitCommandError, InvalidGitRepositoryError, Repo, Tree
+from git import NULL_TREE, Blob, GitCommandError, InvalidGitRepositoryError, Repo, Tree
 
 
 def _collect_unique_commits(repo: Repo, log: Any) -> set:
@@ -721,18 +721,12 @@ class GitPythonAdapter:
 
                 # If this is the first commit (no parents), show diff against empty tree
                 if not commit.parents:
-                    diffs = commit.diff(None, create_patch=True)
-                    if not diffs:
-                        return ""
-                    first_diff = diffs[0]
-                    diff_bytes = first_diff.diff
-                    if isinstance(diff_bytes, bytes):
-                        return diff_bytes.decode("utf-8")
-                    return str(diff_bytes) if diff_bytes is not None else ""
-
-                # For commits with parents, show diff against first parent
-                parent = commit.parents[0]
-                diffs = parent.diff(commit, create_patch=True)
+                    # NULL_TREE represents an empty tree to diff against
+                    diffs = commit.diff(NULL_TREE, create_patch=True)
+                else:
+                    # For commits with parents, show diff against first parent
+                    parent = commit.parents[0]
+                    diffs = parent.diff(commit, create_patch=True)
 
                 # Combine all diffs into a single string
                 diff_text = ""

--- a/tests/kodit/infrastructure/cloning/git/test_hash_validation.py
+++ b/tests/kodit/infrastructure/cloning/git/test_hash_validation.py
@@ -33,6 +33,7 @@ def init_repo(repo: Path) -> None:
     git(repo, "init", "-b", "main")
     git(repo, "config", "user.email", "test@example.com")
     git(repo, "config", "user.name", "Test User")
+    git(repo, "config", "commit.gpgsign", "false")
 
 
 def commit_file(repo: Path, filename: str, content: str, message: str) -> None:
@@ -186,3 +187,18 @@ async def test_dulwich_accepts_valid_sha_input(
 
     diff = await dulwich.get_commit_diff(repo, sha)
     assert isinstance(diff, str)
+
+
+@pytest.mark.asyncio
+async def test_get_commit_diff_single_commit(
+    temp_repo: tuple[Path, str], adapter: GitAdapter
+) -> None:
+    """Test get_commit_diff works for repos with only a single commit (no parent)."""
+    repo, _ = temp_repo
+
+    sha = await adapter.get_latest_commit_sha(repo)
+    diff = await adapter.get_commit_diff(repo, sha)
+
+    assert isinstance(diff, str)
+    # The diff should contain the file content from the initial commit
+    assert "Hello" in diff or "test.txt" in diff


### PR DESCRIPTION
When a repository has only one commit (no parents), the diff operations were failing:
- dulwich: The empty tree wasn't added to the object store, causing KeyError when diff_tree tried to look it up
- GitPython: Was using `commit.diff(None)` which returns empty, and only returned the first diff item instead of combining all diffs

Both adapters now correctly diff against an empty tree for the first commit and return the complete diff output.

Also added test to verify all adapters handle single-commit repos, and fixed test fixture to disable gpg signing.
