### PR TITLE
feat(docker): add ARM64 platform support for Apple Silicon

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -95,7 +95,7 @@ jobs:
         id: push
         uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
         with:
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           context: .
           file: ./Dockerfile
           push: true


### PR DESCRIPTION
## Summary
- Adds `linux/arm64` to Docker build platforms alongside existing `linux/amd64`
- Enables kodit to run natively on Apple Silicon Macs

## Problem
Users running Helix on Apple Silicon Macs get this error when pulling the kodit image:
```
Error response from daemon: no matching manifest for linux/arm64/v8 in the manifest list entries
```

The workflow already sets up QEMU and Docker Buildx for multi-arch builds but was only building for amd64.

## Test plan
- [ ] CI passes
- [ ] New release builds both amd64 and arm64 images
- [ ] Verify with `docker buildx imagetools inspect` that both platforms are in the manifest

🤖 Generated with [Claude Code](https://claude.ai/code)