### PR TITLE
fix(docker): tag uv image as debian-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,8 +38,9 @@ EXPOSE 8080
 CMD ["air", "-c", ".air.toml"]
 
 # Model stage — downloads and converts the embedding model to ONNX format
-# Pinned by digest so the layer caches reliably across builds.
-FROM ghcr.io/astral-sh/uv@sha256:b852203fd7831954c58bfa1fec1166295adcfcfa50f4de7fdd0e684c8bd784eb AS model
+# Uses debian-slim variant (not the default distroless) because the Python
+# ML dependencies (torch, onnxruntime) need system libraries and a shell.
+FROM ghcr.io/astral-sh/uv:debian-slim@sha256:b852203fd7831954c58bfa1fec1166295adcfcfa50f4de7fdd0e684c8bd784eb AS model
 WORKDIR /build
 COPY tools/convert-model.py ./tools/convert-model.py
 RUN uv run --script tools/convert-model.py


### PR DESCRIPTION
## Summary
- Adds `:debian-slim` tag to the uv Docker image in the model build stage
- The image was previously pinned by digest only (no tag), which caused Dependabot to track the default **distroless** image instead of the `debian-slim` variant
- This caused PR #379 to fail with `/bin/sh: no such file or directory` because the distroless image has no shell

## Context
The digest `b852203...` is unchanged — this PR only adds the tag for clarity and correct Dependabot tracking. Future digest bumps from Dependabot will now stay within the `debian-slim` variant.

## Test plan
- [ ] Docker build succeeds (CI)
- [ ] Smoke test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)