### PR TITLE
fix(ci): add missing tool deps for make docs workflow

### DIFF
--- a/.github/workflows/update-docs-on-tag.yaml
+++ b/.github/workflows/update-docs-on-tag.yaml
@@ -28,6 +28,12 @@ jobs:
         with:
           node-version: "20"
 
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Install tools
+        run: make tools
+
       - name: Generate docs
         run: make docs
 

--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,7 @@ tools: ## Install development tools
 	$(GOCMD) install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
 	$(GOCMD) install golang.org/x/tools/cmd/goimports@latest
 	$(GOCMD) install github.com/swaggo/swag/cmd/swag@latest
-	$(GOCMD) install golang.org/x/tools/cmd/goimports@latest
+	$(GOCMD) install github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@v2.5.1
 
 ##@ Documentation
 


### PR DESCRIPTION
## Summary
- Adds `astral-sh/setup-uv` and `make tools` steps to the update-docs-on-tag workflow so `make docs` succeeds
- Adds `oapi-codegen` to the Makefile `tools` target (replacing a duplicate `goimports` entry)

## Test plan
- [x] Verified workflow passes on this branch: https://github.com/helixml/kodit/actions/runs/22189839199

🤖 Generated with [Claude Code](https://claude.com/claude-code)