### PR TITLE
docs: update version references to 1.0.0 and add Go SDK docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ BUILD_DIR=./build
 COVERAGE_FILE=coverage.out
 
 # Version info (can be overridden via environment or make args)
-VERSION?=0.1.0
+VERSION?=1.0.0
 COMMIT?=$(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 BUILD_TIME?=$(shell date -u '+%Y-%m-%d_%H:%M:%S')
 

--- a/README.md
+++ b/README.md
@@ -46,12 +46,12 @@ code. This index is used to build a snippet library, ready for ingestion into an
 - Intelligent snippet extraction with context-aware dependencies
 - Efficient indexing with selective reindexing (only processes modified files)
 - Privacy first: respects .gitignore and .noindex files
-- **NEW in 0.3**: Auto-indexing configuration for shared server deployments
-- **NEW in 0.3**: Enhanced Git provider support including Azure DevOps
-- **NEW in 0.3**: Index private repositories via a PAT
-- **NEW in 0.3**: Improved progress monitoring and reporting during indexing
-- **NEW in 0.3**: Advanced code slicing infrastructure with Tree-sitter parsing
-- **NEW in 0.4**: Automatic periodic sync to keep indexes up-to-date
+- Auto-indexing configuration for shared server deployments
+- Enhanced Git provider support including Azure DevOps
+- Index private repositories via a PAT
+- Improved progress monitoring and reporting during indexing
+- Advanced code slicing infrastructure with Tree-sitter parsing
+- Automatic periodic sync to keep indexes up-to-date
 
 ### MCP Server
 
@@ -63,14 +63,15 @@ intent. Kodit has been tested to work well with:
 - Tested and verified with:
   - [Cursor](https://docs.helix.ml/kodit/getting-started/integration/#integration-with-cursor)
   - [Cline](https://docs.helix.ml/kodit/getting-started/integration/#integration-with-cline)
+  - [Claude Code](https://docs.helix.ml/kodit/reference/mcp/)
 - Please contribute more instructions! ... any other assistant is likely to work ...
-- **New in 0.3**: Advanced search filters by source, language, author, date range, and file path
-- **New in 0.3**: Hybrid search combining BM25 keyword search with semantic search
-- **New in 0.4**: Enhanced MCP tools with rich context parameters and metadata
+- Advanced search filters by source, language, author, date range, and file path
+- Hybrid search combining BM25 keyword search with semantic search
+- Enhanced MCP tools with rich context parameters and metadata
 
 ### Hosted MCP Server
 
-**New in 0.4**: Try Kodit instantly with our hosted MCP server at [https://kodit.helix.ml/mcp](https://kodit.helix.ml/mcp)! No installation required - just add it to your AI coding assistant and start searching popular codebases immediately.
+Try Kodit instantly with our hosted MCP server at [https://kodit.helix.ml/mcp](https://kodit.helix.ml/mcp)! No installation required - just add it to your AI coding assistant and start searching popular codebases immediately.
 
 The hosted server provides:
 
@@ -100,7 +101,7 @@ Supported providers:
 - Secure, private LLM enclave with [Helix](https://helix.ml).
 - Any other OpenAI compatible API
 
-**NEW in 0.3**: Enhanced deployment options:
+Enhanced deployment options:
 
 - Docker Compose configurations with VectorChord
 - Kubernetes manifests for production deployments
@@ -128,4 +129,4 @@ please [open a discussion](https://github.com/helixml/kodit/discussions).
 
 ## License
 
-[Apache 2.0 © 2025 HelixML, Inc.](./LICENSE)
+[Apache 2.0 © 2026 HelixML, Inc.](./LICENSE)

--- a/charts/kodit/Chart.yaml
+++ b/charts/kodit/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kodit
 description: A Helm chart for Kodit
 type: application
-version: 0.1.2
+version: 1.0.0
 appVersion: "1.0.0"
 dependencies:
   - name: common

--- a/docs/reference/go-sdk/index.md
+++ b/docs/reference/go-sdk/index.md
@@ -1,0 +1,237 @@
+---
+title: Go SDK Reference
+description: Kodit Go Library and HTTP Client API Reference
+weight: 31
+---
+
+Kodit provides two Go packages for programmatic access:
+
+1. **`github.com/helixml/kodit`** — The core library for embedding Kodit directly into your Go application
+2. **`github.com/helixml/kodit/clients/go`** — A generated HTTP client for calling a remote Kodit server
+
+## Go Library
+
+### Installation
+
+```bash
+go get github.com/helixml/kodit
+```
+
+### Creating a Client
+
+The `kodit.Client` is the main entry point. Create one with `kodit.New()` and configure it with functional options.
+
+#### SQLite (local, single-process)
+
+```go
+import "github.com/helixml/kodit"
+
+client, err := kodit.New(
+    kodit.WithSQLite("/path/to/data.db"),
+)
+if err != nil {
+    log.Fatal(err)
+}
+defer client.Close()
+```
+
+#### PostgreSQL with VectorChord (production, multi-process)
+
+```go
+client, err := kodit.New(
+    kodit.WithPostgresVectorchord("postgres://user:pass@localhost:5432/kodit"),
+    kodit.WithOpenAI(os.Getenv("OPENAI_API_KEY")),
+)
+```
+
+### Configuration Options
+
+| Option | Description |
+|--------|-------------|
+| `WithSQLite(path)` | Use SQLite as the database. BM25 uses FTS5, vector search uses the configured embedding provider. |
+| `WithPostgresVectorchord(dsn)` | Use PostgreSQL with the VectorChord extension for BM25 and vector search. |
+| `WithOpenAI(apiKey)` | Set OpenAI as the AI provider for text generation and embeddings. |
+| `WithOpenAIConfig(cfg)` | Set OpenAI with custom configuration (base URL, model overrides). |
+| `WithAnthropic(apiKey)` | Set Anthropic Claude as the text generation provider. Requires a separate embedding provider. |
+| `WithAnthropicConfig(cfg)` | Set Anthropic Claude with custom configuration. |
+| `WithTextProvider(p)` | Set a custom text generation provider. |
+| `WithEmbeddingProvider(p)` | Set a custom embedding provider. |
+| `WithDataDir(dir)` | Set the data directory for cloned repositories and storage. Defaults to `~/.kodit`. |
+| `WithCloneDir(dir)` | Set the directory where repositories are cloned. Defaults to `{dataDir}/repos`. |
+| `WithModelDir(dir)` | Set the directory for built-in model files. Defaults to `{dataDir}/models`. |
+| `WithLogger(l)` | Set a custom `*slog.Logger`. |
+| `WithAPIKeys(keys...)` | Set API keys for HTTP API authentication. |
+| `WithWorkerCount(n)` | Set the number of background worker goroutines. Defaults to 1. |
+| `WithWorkerPollPeriod(d)` | Set how often the background worker checks for new tasks. Defaults to 1s. |
+| `WithPeriodicSyncConfig(cfg)` | Configure periodic repository sync intervals. |
+
+### Services
+
+The `Client` exposes services as public fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `Repositories` | `*service.Repository` | Add, delete, sync, and query repositories |
+| `Commits` | `*service.Commit` | Query indexed commits |
+| `Tags` | `*service.Tag` | Query repository tags |
+| `Files` | `*service.File` | Query indexed files |
+| `Enrichments` | `*service.Enrichment` | Query enrichments (snippets, architecture docs, etc.) |
+| `Tasks` | `*service.Queue` | Inspect and manage the background task queue |
+| `Tracking` | `*service.Tracking` | Monitor indexing progress |
+| `Search` | `*service.Search` | Hybrid code search (BM25 + vector) |
+
+### Usage Examples
+
+#### Adding and Indexing a Repository
+
+```go
+import "github.com/helixml/kodit/application/service"
+
+source, created, err := client.Repositories.Add(ctx, &service.RepositoryAddParams{
+    URL:    "https://github.com/kubernetes/kubernetes",
+    Branch: "master",
+})
+if err != nil {
+    log.Fatal(err)
+}
+
+// Indexing runs automatically in the background worker.
+// Wait for the worker to finish:
+for !client.WorkerIdle() {
+    time.Sleep(time.Second)
+}
+```
+
+#### Searching Code
+
+```go
+results, err := client.Search.Query(ctx, "create a deployment",
+    service.WithSemanticWeight(0.7),
+    service.WithLimit(10),
+    service.WithLanguages("go"),
+)
+if err != nil {
+    log.Fatal(err)
+}
+
+for _, enrichment := range results.Enrichments() {
+    fmt.Printf("ID: %d, Language: %s\n", enrichment.ID(), enrichment.Language())
+    fmt.Println(enrichment.Content())
+}
+```
+
+##### Search Options
+
+| Option | Description |
+|--------|-------------|
+| `WithSemanticWeight(w)` | Weight for semantic (vector) search, 0.0 to 1.0 |
+| `WithLimit(n)` | Maximum number of results |
+| `WithOffset(n)` | Offset for pagination |
+| `WithLanguages(langs...)` | Filter by programming languages |
+| `WithRepositories(ids...)` | Filter by repository IDs |
+| `WithEnrichmentTypes(types...)` | Filter by enrichment types |
+| `WithMinScore(score)` | Minimum score threshold |
+| `WithSnippets(bool)` | Include code snippets |
+| `WithDocuments(bool)` | Include enrichment documents |
+
+#### Querying Commits and Files
+
+```go
+import "github.com/helixml/kodit/domain/repository"
+
+// Find all commits for a repository
+commits, err := client.Commits.Find(ctx, repository.WithRepoID(repoID))
+
+// Find files
+files, err := client.Files.Find(ctx, repository.WithRepoID(repoID))
+```
+
+### Error Handling
+
+The `kodit` package exports sentinel errors for common failure modes:
+
+| Error | Description |
+|-------|-------------|
+| `ErrNoDatabase` | No database was configured |
+| `ErrNoProvider` | No AI provider was configured |
+| `ErrProviderNotCapable` | The provider lacks a required capability |
+| `ErrNotFound` | A requested resource was not found |
+| `ErrValidation` | A validation error occurred |
+| `ErrConflict` | A conflict with existing data |
+| `ErrEmptySource` | A source with no content to process |
+| `ErrClientClosed` | The client has been closed |
+
+Use `errors.Is` to check:
+
+```go
+_, err := client.Search.Query(ctx, "test")
+if errors.Is(err, kodit.ErrClientClosed) {
+    // handle closed client
+}
+```
+
+### Lifecycle
+
+- **`Close()`** — Stops the background worker and periodic sync, closes the embedding provider and database. Always defer this after creating a client.
+- **`WorkerIdle()`** — Reports whether the background worker has no in-flight tasks. Useful for waiting until indexing completes.
+
+---
+
+## Go HTTP Client
+
+The `clients/go` package provides a generated HTTP client for calling a remote Kodit server's REST API.
+
+### Installation
+
+```bash
+go get github.com/helixml/kodit/clients/go
+```
+
+### Creating an HTTP Client
+
+```go
+import koditclient "github.com/helixml/kodit/clients/go"
+
+client, err := koditclient.NewClient("https://kodit.example.com")
+if err != nil {
+    log.Fatal(err)
+}
+```
+
+You can pass a custom `http.Client` for authentication or transport configuration:
+
+```go
+httpClient := &http.Client{
+    Timeout: 30 * time.Second,
+}
+client, err := koditclient.NewClient(
+    "https://kodit.example.com",
+    koditclient.WithHTTPClient(httpClient),
+)
+```
+
+### Usage
+
+The client exposes methods matching the [REST API](../api/):
+
+```go
+// List repositories
+resp, err := client.GetApiV1Repositories(ctx)
+
+// Add a repository
+resp, err := client.PostApiV1Repositories(ctx, koditclient.PostApiV1RepositoriesJSONRequestBody{
+    Url: "https://github.com/example/repo",
+})
+
+// Search
+resp, err := client.PostApiV1SearchMulti(ctx, koditclient.PostApiV1SearchMultiJSONRequestBody{
+    TextQuery: "create a deployment",
+    TopK:      10,
+})
+```
+
+### Notes
+
+- Types are auto-generated from the Kodit OpenAPI specification using [oapi-codegen](https://github.com/oapi-codegen/oapi-codegen).
+- The generated client provides type-safe request and response structs for all API endpoints.
+- See the [Server API Reference](../api/) for the full list of available endpoints.

--- a/infrastructure/api/api_server.go
+++ b/infrastructure/api/api_server.go
@@ -74,7 +74,7 @@ func (a *APIServer) mountRoutes(router chi.Router) {
 	// MCP uses streaming responses and manages its own session state via
 	// response headers, which is incompatible with chi's Timeout middleware
 	// that wraps the ResponseWriter.
-	mcpSrv := mcpinternal.NewServer(c.Search, c.Repositories, c.Commits, c.Enrichments, "0.1.0", a.logger)
+	mcpSrv := mcpinternal.NewServer(c.Search, c.Repositories, c.Commits, c.Enrichments, "1.0.0", a.logger)
 	httpHandler := server.NewStreamableHTTPServer(mcpSrv.MCPServer())
 	router.Mount("/mcp", httpHandler)
 }

--- a/infrastructure/api/mcp_test.go
+++ b/infrastructure/api/mcp_test.go
@@ -97,8 +97,8 @@ func TestMCPEndpoint_Initialize(t *testing.T) {
 	if resp.Result.ServerInfo.Name != "kodit" {
 		t.Errorf("server name = %q, want kodit", resp.Result.ServerInfo.Name)
 	}
-	if resp.Result.ServerInfo.Version != "0.1.0" {
-		t.Errorf("server version = %q, want 0.1.0", resp.Result.ServerInfo.Version)
+	if resp.Result.ServerInfo.Version != "1.0.0" {
+		t.Errorf("server version = %q, want 1.0.0", resp.Result.ServerInfo.Version)
 	}
 	if resp.Result.Capabilities.Tools == nil {
 		t.Error("expected tools capability to be present")
@@ -311,7 +311,7 @@ func TestMCPEndpoint_ServerMiddlewareStack(t *testing.T) {
 	if isError {
 		t.Fatalf("get_version returned error: %s", text)
 	}
-	if text != "0.1.0" {
-		t.Errorf("expected version 0.1.0, got %s", text)
+	if text != "1.0.0" {
+		t.Errorf("expected version 1.0.0, got %s", text)
 	}
 }

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -95,7 +95,7 @@ func NewServer(
 
 	mcpServer := server.NewMCPServer(
 		"kodit",
-		"0.1.0",
+		"1.0.0",
 		server.WithToolCapabilities(true),
 		server.WithInstructions(instructions),
 	)

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -174,7 +174,7 @@ func testServer() *Server {
 		&fakeRepositoryLister{repos: []repository.Repository{testRepo()}},
 		&fakeCommitFinder{commits: []repository.Commit{testCommit()}},
 		&fakeEnrichmentQuery{enrichments: []enrichment.Enrichment{testArchEnrichment()}},
-		"0.1.0-test",
+		"1.0.0-test",
 		nil,
 	)
 }
@@ -200,8 +200,8 @@ func TestServer_Initialize(t *testing.T) {
 	if result.ServerInfo.Name != "kodit" {
 		t.Errorf("expected server name kodit, got %s", result.ServerInfo.Name)
 	}
-	if result.ServerInfo.Version != "0.1.0" {
-		t.Errorf("expected version 0.1.0, got %s", result.ServerInfo.Version)
+	if result.ServerInfo.Version != "1.0.0" {
+		t.Errorf("expected version 1.0.0, got %s", result.ServerInfo.Version)
 	}
 	if result.Capabilities.Tools == nil {
 		t.Error("expected tools capability to be present")
@@ -350,8 +350,8 @@ func TestServer_GetVersion(t *testing.T) {
 	}
 
 	text := textFromContent(t, result)
-	if text != "0.1.0-test" {
-		t.Errorf("expected version 0.1.0-test, got %s", text)
+	if text != "1.0.0-test" {
+		t.Errorf("expected version 1.0.0-test, got %s", text)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Bump all version strings from 0.1.0 to 1.0.0 (Makefile, Helm chart, MCP server, API server, and their tests)
- Remove pre-release "NEW in 0.x" markers from README — features remain listed as established 1.0 capabilities
- Add Claude Code to tested integrations in README and update copyright year to 2026
- Add Go SDK reference documentation (`docs/reference/go-sdk/index.md`) covering the library API and generated HTTP client

## Test plan

- [x] `make check` passes (0 lint issues)
- [x] `make test` passes (all MCP server tests updated with 1.0.0 expectations)
- [ ] Verify rendered docs site shows Go SDK page in reference section

🤖 Generated with [Claude Code](https://claude.com/claude-code)