### PR TITLE
feat(api): move API key auth from global to write-only protection

### DIFF
--- a/cmd/kodit/serve.go
+++ b/cmd/kodit/serve.go
@@ -142,13 +142,12 @@ func runServe(envFile, host string, port int) error {
 	}()
 
 	// Create API server with the client's services
-	apiServer := api.NewAPIServer(client)
+	apiServer := api.NewAPIServer(client, cfg.APIKeys())
 	router := apiServer.Router()
 
 	// Apply custom middleware (MUST be done before MountRoutes)
 	router.Use(apimiddleware.Logging(slogger))
 	router.Use(apimiddleware.CorrelationID)
-	router.Use(apimiddleware.APIKeyAuth(cfg.APIKeys()))
 
 	// Mount API routes after middleware is configured
 	apiServer.MountRoutes()

--- a/infrastructure/api/api_server_test.go
+++ b/infrastructure/api/api_server_test.go
@@ -1,0 +1,91 @@
+package api_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/helixml/kodit/infrastructure/api"
+)
+
+func TestAPIServer_ReadEndpointsOpen_WriteEndpointsProtected(t *testing.T) {
+	client := newMCPTestClient(t)
+	apiKeys := []string{"test-secret-key"}
+	apiServer := api.NewAPIServer(client, apiKeys)
+	router := apiServer.Router()
+
+	apiServer.MountRoutes()
+
+	docsRouter := apiServer.DocsRouter("/docs/openapi.json")
+	router.Mount("/docs", docsRouter.Routes())
+
+	handler := router
+
+	t.Run("GET /docs returns 200 without API key", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/docs/", nil)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
+		}
+	})
+
+	t.Run("GET /api/v1/repositories returns 200 without API key", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/repositories", nil)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
+		}
+	})
+
+	t.Run("POST /api/v1/repositories without key returns 401", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/repositories", strings.NewReader(`{"url":"https://github.com/test/repo","branch":"main"}`))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+
+		if w.Code != http.StatusUnauthorized {
+			t.Errorf("status = %d, want %d; body: %s", w.Code, http.StatusUnauthorized, w.Body.String())
+		}
+	})
+
+	t.Run("POST /api/v1/repositories with valid key passes auth", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/repositories", strings.NewReader(`{"url":"https://github.com/test/repo","branch":"main"}`))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("X-API-KEY", "test-secret-key")
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+
+		// Should pass auth — may get a different status depending on the handler
+		// logic, but definitely not 401.
+		if w.Code == http.StatusUnauthorized {
+			t.Errorf("status = %d, should not be 401 with valid key", w.Code)
+		}
+	})
+
+	t.Run("DELETE /api/v1/repositories/nonexistent without key returns 401", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodDelete, "/api/v1/repositories/nonexistent", nil)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+
+		if w.Code != http.StatusUnauthorized {
+			t.Errorf("status = %d, want %d; body: %s", w.Code, http.StatusUnauthorized, w.Body.String())
+		}
+	})
+
+	t.Run("POST /api/v1/search without key returns 200", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/search", strings.NewReader(`{"query":"test"}`))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+
+		// Search is open — should not be 401.
+		if w.Code == http.StatusUnauthorized {
+			t.Errorf("search should be open but got 401")
+		}
+	})
+}

--- a/infrastructure/api/mcp_test.go
+++ b/infrastructure/api/mcp_test.go
@@ -62,7 +62,7 @@ func postMCP(t *testing.T, handler http.Handler, body []byte, sessionID string) 
 
 func TestMCPEndpoint_Initialize(t *testing.T) {
 	client := newMCPTestClient(t)
-	apiServer := api.NewAPIServer(client)
+	apiServer := api.NewAPIServer(client, nil)
 	handler := apiServer.Handler()
 
 	body := mcpRequest(t, "initialize", 1, map[string]any{
@@ -107,7 +107,7 @@ func TestMCPEndpoint_Initialize(t *testing.T) {
 
 func TestMCPEndpoint_ListTools(t *testing.T) {
 	client := newMCPTestClient(t)
-	apiServer := api.NewAPIServer(client)
+	apiServer := api.NewAPIServer(client, nil)
 	handler := apiServer.Handler()
 
 	// Initialize first and capture session ID
@@ -168,7 +168,7 @@ func TestMCPEndpoint_ListTools(t *testing.T) {
 
 func TestMCPEndpoint_RejectsInvalidContentType(t *testing.T) {
 	client := newMCPTestClient(t)
-	apiServer := api.NewAPIServer(client)
+	apiServer := api.NewAPIServer(client, nil)
 	handler := apiServer.Handler()
 
 	req := httptest.NewRequest(http.MethodPost, "/mcp", bytes.NewReader([]byte("{}")))
@@ -239,7 +239,7 @@ func TestMCPEndpoint_ToolCallResolvesLatestCommit(t *testing.T) {
 		t.Fatalf("add repository: %v", err)
 	}
 
-	apiServer := api.NewAPIServer(client)
+	apiServer := api.NewAPIServer(client, nil)
 	handler := apiServer.Handler()
 	sessionID := initMCPSession(t, handler)
 
@@ -277,7 +277,7 @@ func TestMCPEndpoint_ToolCallResolvesLatestCommit(t *testing.T) {
 // own response headers for session state.
 func TestMCPEndpoint_ServerMiddlewareStack(t *testing.T) {
 	client := newMCPTestClient(t)
-	apiServer := api.NewAPIServer(client)
+	apiServer := api.NewAPIServer(client, nil)
 	apiServer.MountRoutes()
 
 	// Build the same handler stack as ListenAndServe: the Server router

--- a/infrastructure/api/middleware/auth_test.go
+++ b/infrastructure/api/middleware/auth_test.go
@@ -1,0 +1,115 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func okHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+func TestWriteProtect_GET_PassesWithoutKey(t *testing.T) {
+	config := NewAuthConfigWithKeys([]string{"secret"})
+	handler := WriteProtect(config)(okHandler())
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("GET without key: status = %d, want %d", w.Code, http.StatusOK)
+	}
+}
+
+func TestWriteProtect_HEAD_PassesWithoutKey(t *testing.T) {
+	config := NewAuthConfigWithKeys([]string{"secret"})
+	handler := WriteProtect(config)(okHandler())
+
+	req := httptest.NewRequest(http.MethodHead, "/", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("HEAD without key: status = %d, want %d", w.Code, http.StatusOK)
+	}
+}
+
+func TestWriteProtect_OPTIONS_PassesWithoutKey(t *testing.T) {
+	config := NewAuthConfigWithKeys([]string{"secret"})
+	handler := WriteProtect(config)(okHandler())
+
+	req := httptest.NewRequest(http.MethodOptions, "/", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("OPTIONS without key: status = %d, want %d", w.Code, http.StatusOK)
+	}
+}
+
+func TestWriteProtect_MutatingMethods_RequireKey(t *testing.T) {
+	config := NewAuthConfigWithKeys([]string{"secret"})
+	handler := WriteProtect(config)(okHandler())
+
+	methods := []string{http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete}
+	for _, method := range methods {
+		req := httptest.NewRequest(method, "/", nil)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+
+		if w.Code != http.StatusUnauthorized {
+			t.Errorf("%s without key: status = %d, want %d", method, w.Code, http.StatusUnauthorized)
+		}
+	}
+}
+
+func TestWriteProtect_MutatingMethods_PassWithValidKey(t *testing.T) {
+	config := NewAuthConfigWithKeys([]string{"secret"})
+	handler := WriteProtect(config)(okHandler())
+
+	methods := []string{http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete}
+	for _, method := range methods {
+		req := httptest.NewRequest(method, "/", nil)
+		req.Header.Set("X-API-KEY", "secret")
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Errorf("%s with valid key: status = %d, want %d", method, w.Code, http.StatusOK)
+		}
+	}
+}
+
+func TestWriteProtect_Disabled_PassesAll(t *testing.T) {
+	config := NewAuthConfigWithKeys(nil)
+	handler := WriteProtect(config)(okHandler())
+
+	methods := []string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete}
+	for _, method := range methods {
+		req := httptest.NewRequest(method, "/", nil)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Errorf("%s with auth disabled: status = %d, want %d", method, w.Code, http.StatusOK)
+		}
+	}
+}
+
+func TestWriteProtect_InvalidKey_Rejected(t *testing.T) {
+	config := NewAuthConfigWithKeys([]string{"secret"})
+	handler := WriteProtect(config)(okHandler())
+
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	req.Header.Set("X-API-KEY", "wrong")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("POST with invalid key: status = %d, want %d", w.Code, http.StatusUnauthorized)
+	}
+}


### PR DESCRIPTION
## Summary

- **Add `WriteProtect` middleware** that only enforces API key auth for mutating HTTP methods (POST, PUT, PATCH, DELETE); safe methods (GET, HEAD, OPTIONS) pass through
- **Restructure route mounting** so `/search` and `/queue` are open, while `/repositories` and `/enrichments` use write-protection
- **Remove global auth middleware** from `serve.go` — read-only consumers (search, MCP, docs browsing) no longer need an API key

## Test plan

- [x] `WriteProtect` middleware unit tests: GET/HEAD/OPTIONS pass without key, POST/PUT/PATCH/DELETE require valid key, auth disabled passes all
- [x] Integration test: GET `/docs` returns 200, GET `/api/v1/repositories` returns 200, POST `/api/v1/repositories` returns 401 without key, POST `/api/v1/search` remains open
- [x] `make check` passes (0 lint issues)
- [x] `make test` passes (all existing + new tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)