### PR TITLE
Optimize Docker build with cache mounts and parallel stage execution

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -16,7 +16,9 @@ lib/
 *.so
 *.dylib
 
-# Models are pre-downloaded by 'make download-model' and copied into the image
+# Models are built inside the Docker image by the model stage — exclude local
+# copies to avoid sending them to the build context and overwriting the stage output.
+infrastructure/provider/models/
 
 # Test files
 *_test.go


### PR DESCRIPTION
- Add BuildKit cache mounts for Go module cache, Go build cache, and uv package cache so repeated builds skip redundant downloads/compilation
- Move COPY --from=model after COPY . . so the model stage runs in parallel with the builder's apt-get, mod download, and ORT download steps instead of blocking them
- Exclude infrastructure/provider/models/ from .dockerignore to prevent local model files from inflating the build context and overwriting the model stage output

https://claude.ai/code/session_019FVuvj4qEpSjVrEtYy47fT

## Description
<!-- Please provide a brief description of the changes in this PR -->

## Related Issue
<!-- If this PR fixes an issue, please link it here using the format: Fixes #123 -->

## Type of Change
<!-- Please check the relevant boxes with [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe)

## Checklist:
<!-- Please check the relevant boxes with [x] -->

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional Notes
<!-- Add any additional notes about the PR here --> 