### PR TITLE
docs: update README and documentation to reflect current features

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 </p>
 
 <h1 align="center">
-Kodit: A Code Indexing MCP Server
+Kodit: Code Understanding MCP Server
 </h1>
 
 <p align="center">
-Kodit connects your AI coding assistant to external codebases to provide accurate and up-to-date snippets of code.
+Kodit indexes Git repositories and connects your AI coding assistant to accurate, up-to-date code and documentation.
 </p>
 
 <div align="center">
@@ -20,78 +20,112 @@ Kodit connects your AI coding assistant to external codebases to provide accurat
 
 :star: _Help us reach more developers and grow the Helix community. Star this repo!_
 
-**Helix Kodit** is an **MCP server** that connects your AI coding assistant to external codebases. It can:
+**Helix Kodit** is a code understanding platform that indexes Git repositories and
+provides hybrid search with LLM-powered enrichments via MCP and a REST API. It can:
 
-- Improve your AI-assisted code by providing canonical examples direct from the source
-- Index local and public codebases
-- Integrates with any AI coding assistant via MCP
-- Search using keyword and semantic search
-- Integrate with any OpenAI-compatible or custom API/model
+- Index public and private Git repositories
+- Generate AI-powered documentation (architecture docs, API docs, database schemas, cookbooks, wikis)
+- Search using BM25 keyword, semantic similarity, and hybrid search
+- Expose code intelligence via MCP for any AI coding assistant
+- Browse repository files with grep, ls, and raw file access
+- Integrate with any OpenAI-compatible API or run fully local
 
-If you're an engineer working with AI-powered coding assistants, Kodit helps by
-providing relevant and up-to-date examples of your task so that LLMs make fewer mistakes
-and produce fewer hallucinations.
+If you're an engineer working with AI-powered coding assistants, Kodit helps by providing
+relevant and up-to-date examples and documentation so that LLMs make fewer mistakes and
+produce fewer hallucinations.
 
 ## Features
 
 ### Codebase Indexing
 
-Kodit connects to a variety of local and remote codebases to build an index of your
-code. This index is used to build a snippet library, ready for ingestion into an LLM.
+Kodit clones Git repositories and runs a multi-stage indexing pipeline:
 
-- Index local directories and public Git repositories
-- Build comprehensive snippet libraries for LLM ingestion
+- **Clone and scan** Git metadata (commits, branches, tags)
+- **Chunk source files** into fixed-size, overlapping text segments
+- **Build search indexes** for BM25 keyword search, code embeddings, and text embeddings
+- **AI enrichment** (with an LLM provider): architecture docs, API docs, database schemas, cookbook entries, commit summaries, and a full wiki
 - Support for 20+ programming languages including Python, JavaScript/TypeScript, Java, Go, Rust, C/C++, C#, HTML/CSS, and more
-- Advanced code analysis with dependency tracking and call graph generation
-- Intelligent snippet extraction with context-aware dependencies
-- Efficient indexing with selective reindexing (only processes modified files)
-- Privacy first: respects .gitignore and .noindex files
-- Auto-indexing configuration for shared server deployments
-- Enhanced Git provider support including Azure DevOps
-- Index private repositories via a PAT
-- Improved progress monitoring and reporting during indexing
-- Advanced code slicing infrastructure with Tree-sitter parsing
+- Efficient incremental indexing (only processes new/modified commits)
 - Automatic periodic sync to keep indexes up-to-date
+- Configurable pipeline presets: full pipeline with LLM enrichments, or RAG-only for lightweight search
 
 ### MCP Server
 
-Relevant snippets are exposed to an AI coding assistant via an MCP server. This allows
-the assistant to request relevant snippets by providing keywords, code, and semantic
-intent. Kodit has been tested to work well with:
+Kodit exposes 14 MCP tools to AI coding assistants:
 
-- Seamless integration with popular AI coding assistants
-- Tested and verified with:
-  - [Cursor](https://docs.helix.ml/kodit/getting-started/integration/#integration-with-cursor)
-  - [Cline](https://docs.helix.ml/kodit/getting-started/integration/#integration-with-cline)
-  - [Claude Code](https://docs.helix.ml/kodit/reference/mcp/)
-- Please contribute more instructions! ... any other assistant is likely to work ...
-- Advanced search filters by source, language, author, date range, and file path
-- Hybrid search combining BM25 keyword search with semantic search
-- Enhanced MCP tools with rich context parameters and metadata
+| Tool | Description |
+|------|-------------|
+| `kodit_repositories` | List all indexed repositories |
+| `kodit_version` | Get the server version |
+| `kodit_architecture_docs` | High-level architecture documentation |
+| `kodit_api_docs` | API/interface documentation |
+| `kodit_database_schema` | Database schema documentation |
+| `kodit_cookbook` | Usage examples and cookbook entries |
+| `kodit_commit_description` | Commit description and summary |
+| `kodit_wiki` | Table of contents for a repository's wiki |
+| `kodit_wiki_page` | Content of a specific wiki page |
+| `kodit_semantic_search` | Semantic similarity search with file URIs |
+| `kodit_keyword_search` | BM25 keyword search with file URIs |
+| `kodit_grep` | Regex search via git grep |
+| `kodit_ls` | List files matching a glob pattern |
+| `kodit_read_resource` | Read file contents from a resource URI |
+
+Tested and verified with [Cursor](https://docs.helix.ml/kodit/reference/mcp/),
+[Cline](https://docs.helix.ml/kodit/reference/mcp/),
+[Claude Code](https://docs.helix.ml/kodit/reference/mcp/), and
+[Kilo Code](https://docs.helix.ml/kodit/reference/mcp/).
+Any MCP-compatible assistant should work.
+
+### Go SDK
+
+Kodit can be embedded directly into Go applications as a library:
+
+```go
+client, err := kodit.New(
+    kodit.WithSQLite("/path/to/data.db"),
+    kodit.WithOpenAI(os.Getenv("OPENAI_API_KEY")),
+)
+defer client.Close()
+
+// Index a repository
+repo, _, err := client.Repositories.Add(ctx, &service.RepositoryAddParams{
+    URL: "https://github.com/example/repo",
+})
+
+// Search
+results, err := client.Search.Query(ctx, "create a deployment",
+    service.WithSemanticWeight(0.7),
+    service.WithLimit(10),
+)
+```
+
+A generated HTTP client (`clients/go`) is also available for calling a remote Kodit server.
+See the [Go SDK reference](https://docs.helix.ml/kodit/reference/go-sdk/) for details.
 
 ### Enterprise Ready
 
-Out of the box, Kodit works with a local SQLite database and very small, local models.
-But enterprises can scale out with performant databases and dedicated models. Everything
-can even run securely, privately, with on-premise LLM platforms like
-[Helix](https://helix.ml).
+Out of the box, Kodit works with a local SQLite database and a built-in CPU-only embedding
+model. Enterprises can scale out with performant databases and dedicated models. Everything
+can run securely and privately with on-premise LLM platforms like [Helix](https://helix.ml).
 
 Supported databases:
 
-- SQLite
-- [Vectorchord](https://github.com/tensorchord/VectorChord)
+- SQLite (with FTS5 for BM25)
+- [VectorChord](https://github.com/tensorchord/VectorChord) (PostgreSQL extension for BM25 and vector search)
 
 Supported providers:
 
-- Local (which uses tiny CPU-only open-source models)
+- Built-in local embedding model (CPU-only, no external dependencies)
 - OpenAI
-- Secure, private LLM enclave with [Helix](https://helix.ml).
-- Any other OpenAI compatible API
+- Anthropic (text generation only; requires a separate embedding provider)
+- Any OpenAI-compatible API (via LiteLLM)
+- Secure, private LLM enclave with [Helix](https://helix.ml)
 
-Enhanced deployment options:
+Deployment options:
 
-- Docker Compose configurations with VectorChord
-- Kubernetes manifests for production deployments
+- Docker and Docker Compose
+- Kubernetes manifests
+- Pre-built binaries for Linux and macOS
 
 ## Quick Start
 
@@ -103,13 +137,14 @@ Enhanced deployment options:
 
 - [Getting Started Guide](https://docs.helix.ml/kodit/getting-started/)
 - [Reference Guide](https://docs.helix.ml/kodit/reference/)
+- [Demos](https://docs.helix.ml/kodit/demos/)
 - [Contribution Guidelines](.github/CONTRIBUTING.md)
 
 ## Roadmap
 
 The roadmap is currently maintained as a [Github Project](https://github.com/orgs/helixml/projects/4).
 
-## 💬 Support
+## Support
 
 For commercial support, please contact [Helix.ML](founders@helix.ml). To ask a question,
 please [open a discussion](https://github.com/helixml/kodit/discussions).

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "Kodit: Code Indexing MCP Server"
+title: "Kodit: Code Understanding MCP Server"
 linkTitle: Kodit Docs
 cascade:
   type: docs
@@ -18,7 +18,7 @@ aliases:
 </p>
 
 <p align="center">
-Kodit connects your AI coding assistant to external codebases to provide accurate and up-to-date snippets of code.
+Kodit indexes Git repositories and connects your AI coding assistant to accurate, up-to-date code and documentation.
 </p>
 
 <div class="flex justify-center items-center gap-4">
@@ -28,78 +28,86 @@ Kodit connects your AI coding assistant to external codebases to provide accurat
 
 </div>
 
-**Helix Kodit** is an **MCP server** that connects your AI coding assistant to external codebases. It can:
+**Helix Kodit** is a code understanding platform that indexes Git repositories and
+provides hybrid search with LLM-powered enrichments via MCP and a REST API. It can:
 
-- Improve your AI-assisted code by providing canonical examples direct from the source
-- Index local and public codebases
-- Integrates with any AI coding assistant via MCP
-- Search using keyword and semantic search
-- Integrate with any OpenAI-compatible or custom API/model
+- Index public and private Git repositories
+- Generate AI-powered documentation (architecture docs, API docs, database schemas, cookbooks, wikis)
+- Search using BM25 keyword, semantic similarity, and hybrid search
+- Expose code intelligence via MCP for any AI coding assistant
+- Browse repository files with grep, ls, and raw file access
+- Integrate with any OpenAI-compatible API or run fully local
 
-If you're an engineer working with AI-powered coding assistants, Kodit helps by
-providing relevant and up-to-date examples of your task so that LLMs make less mistakes
-and produce fewer hallucinations.
+If you're an engineer working with AI-powered coding assistants, Kodit helps by providing
+relevant and up-to-date examples and documentation so that LLMs make fewer mistakes and
+produce fewer hallucinations.
 
 ## Features
 
 ### Codebase Indexing
 
-Kodit connects to remote codebases to build an index of your
-code. This index is used to build a snippet library, ready for ingestion into an LLM.
+Kodit clones Git repositories and runs a multi-stage indexing pipeline:
 
-- Index public and private Git repositories (via a PAT)
-- Build comprehensive snippet libraries for LLM ingestion
-- Support for 20+ programming languages including Python, JavaScript/TypeScript, Java, Go, Rust, C/C++, C#, HTML/CSS, and more
-- Fixed-size text chunking with configurable size and overlap
-- Efficient indexing with selective reindexing (only processes modified files)
-- Privacy first: respects .gitignore and .noindex files
-- Enhanced Git provider support including Github, Gitlab, Azure DevOps
-- Index Git structure for incremental indexing and unlock future enrichments
+- Clone and scan Git metadata (commits, branches, tags)
+- Chunk source files into fixed-size, overlapping text segments
+- Build search indexes for BM25 keyword search, code embeddings, and text embeddings
+- AI enrichment (with an LLM provider): architecture docs, API docs, database schemas, cookbook entries, commit summaries, and a full wiki
+- Support for 20+ programming languages
+- Efficient incremental indexing (only processes new/modified commits)
+- Automatic periodic sync to keep indexes up-to-date
+- Configurable pipeline: full (with LLM enrichments) or RAG-only (lightweight search)
 
 ### MCP Server
 
-Relevant snippets are exposed to an AI coding assistant via an MCP server. This allows
-the assistant to request relevant snippets by providing keywords, code, and semantic
-intent. Kodit has been tested to work well with:
+Kodit exposes 14 MCP tools to AI coding assistants including search, documentation
+retrieval, file browsing, and wiki access. Tested and verified with:
 
-- Seamless integration with popular AI coding assistants
-- Tested and verified with:
-  - [Cursor](./reference/mcp/index.md)
-  - [Cline](./reference/mcp/index.md)
-  - [Claude Code](./reference/mcp/index.md)
-- Please contribute more instructions! ... any other assistant is likely to work ...
-- Advanced search filters by source, language, author, date range, and file path
-- Hybrid search combining BM25 keyword search with semantic search
+- [Cursor](./reference/mcp/index.md)
+- [Cline](./reference/mcp/index.md)
+- [Claude Code](./reference/mcp/index.md)
+- [Kilo Code](./reference/mcp/index.md)
+- Any MCP-compatible assistant
+
+### Go SDK
+
+Kodit can be embedded directly into Go applications as a library, or accessed via a
+generated HTTP client. See the [Go SDK reference](./reference/go-sdk/index.md).
 
 ### Enterprise Ready
 
-Out of the box, Kodit works with a local SQLite database and very small, local models.
-But enterprises can scale out with performant databases and dedicated models. Everything
-can even run securely, privately, with on-premise LLM platforms like
+Out of the box, Kodit works with a local SQLite database and a built-in CPU-only embedding
+model. Enterprises can scale out with performant databases and dedicated models. Everything
+can run securely and privately with on-premise LLM platforms like
 [Helix](https://helix.ml).
 
 Supported databases:
 
-- SQLite
-- [Vectorchord](https://github.com/tensorchord/VectorChord)
+- SQLite (with FTS5 for BM25)
+- [VectorChord](https://github.com/tensorchord/VectorChord) (PostgreSQL extension)
 
 Supported providers:
 
-- Local (which uses tiny CPU-only open-source models)
-- Secure, private LLM enclave with [Helix](https://helix.ml).
-- Any other provider supported by [LiteLLM](https://docs.litellm.ai/docs/providers).
-- Docker Compose configurations with VectorChord
-- Kubernetes manifests for production deployments
+- Built-in local embedding model (CPU-only)
+- OpenAI
+- Anthropic (text generation only; requires a separate embedding provider)
+- Any OpenAI-compatible API (via LiteLLM)
+- Secure, private LLM enclave with [Helix](https://helix.ml)
+
+Deployment options:
+
+- Docker and Docker Compose
+- Kubernetes manifests
+- Pre-built binaries for Linux and macOS
 
 ## Roadmap
 
 The roadmap is currently maintained as a [Github Project](https://github.com/orgs/helixml/projects/4).
 
-## 💬 Support
+## Support
 
 For commercial support, please contact [Helix.ML](https://docs.helixml.tech/helix/help/). To ask a question,
 please [open a discussion](https://github.com/helixml/kodit/discussions).
 
 ## License
 
-[Apache 2.0 © 2025 HelixML, Inc.](https://github.com/helixml/kodit/blob/main/LICENSE)
+[Apache 2.0 © 2026 HelixML, Inc.](https://github.com/helixml/kodit/blob/main/LICENSE)

--- a/docs/demos/go-simple-microservice/index.md
+++ b/docs/demos/go-simple-microservice/index.md
@@ -62,13 +62,13 @@ Now let's index the microservices and try again:
 
    ```sh
    curl --request POST \
-   --url http://localhost:8080/api/v1/indexes \
+   --url http://localhost:8080/api/v1/repositories \
    --header 'Content-Type: application/json' \
    --data '{
    "data": {
-      "type": "index",
+      "type": "repository",
       "attributes": {
-         "uri": "https://gist.github.com/philwinder/db2e17413332844fa4b14971ae5adb34.git"
+         "remote_uri": "https://gist.github.com/philwinder/db2e17413332844fa4b14971ae5adb34.git"
       }
    }
    }'
@@ -79,13 +79,13 @@ Now let's index the microservices and try again:
 
    ```sh
    curl --request POST \
-   --url http://localhost:8080/api/v1/indexes \
+   --url http://localhost:8080/api/v1/repositories \
    --header 'Content-Type: application/json' \
    --data '{
    "data": {
-      "type": "index",
+      "type": "repository",
       "attributes": {
-         "uri": "https://gist.github.com/philwinder/7aa38185e20433c04c533f2b28f4e217.git"
+         "remote_uri": "https://gist.github.com/philwinder/7aa38185e20433c04c533f2b28f4e217.git"
       }
    }
    }'

--- a/docs/demos/knock-knock-auth/index.md
+++ b/docs/demos/knock-knock-auth/index.md
@@ -80,13 +80,13 @@ Now let's index the code for my secret server and then leverage Kodit in Cursor.
 
    ```sh
    curl --request POST \
-   --url http://localhost:8080/api/v1/indexes \
+   --url http://localhost:8080/api/v1/repositories \
    --header 'Content-Type: application/json' \
    --data '{
    "data": {
-      "type": "index",
+      "type": "repository",
       "attributes": {
-         "uri": "https://gist.github.com/philwinder/cbf0bd1f3338ddf9f98879148d2d752d.git"
+         "remote_uri": "https://gist.github.com/philwinder/cbf0bd1f3338ddf9f98879148d2d752d.git"
       }
    }
    }'

--- a/docs/demos/quant-jupyter/index.md
+++ b/docs/demos/quant-jupyter/index.md
@@ -49,13 +49,13 @@ Let's index the quant helper library and create our analysis notebook:
 
    ```sh
    curl --request POST \
-   --url http://localhost:8080/api/v1/indexes \
+   --url http://localhost:8080/api/v1/repositories \
    --header 'Content-Type: application/json' \
    --data '{
    "data": {
-      "type": "index",
+      "type": "repository",
       "attributes": {
-         "uri": "https://github.com/philwinder/quant-helper"
+         "remote_uri": "https://github.com/philwinder/quant-helper"
       }
    }
    }'

--- a/docs/demos/quant-packaging-kilo/index.md
+++ b/docs/demos/quant-packaging-kilo/index.md
@@ -53,13 +53,13 @@ Let's index the quant helper library and create our analysis notebook:
 
    ```sh
    curl --request POST \
-   --url http://localhost:8080/api/v1/indexes \
+   --url http://localhost:8080/api/v1/repositories \
    --header 'Content-Type: application/json' \
    --data '{
    "data": {
-      "type": "index",
+      "type": "repository",
       "attributes": {
-         "uri": "https://github.com/philwinder/quant-helper"
+         "remote_uri": "https://github.com/philwinder/quant-helper"
       }
    }
    }'
@@ -67,13 +67,13 @@ Let's index the quant helper library and create our analysis notebook:
 
    ```sh
    curl --request POST \
-   --url http://localhost:8080/api/v1/indexes \
+   --url http://localhost:8080/api/v1/repositories \
    --header 'Content-Type: application/json' \
    --data '{
    "data": {
-      "type": "index",
+      "type": "repository",
       "attributes": {
-         "uri": "https://github.com/philwinder/quant-packaging"
+         "remote_uri": "https://github.com/philwinder/quant-packaging"
       }
    }
    }'

--- a/docs/developer/index.md
+++ b/docs/developer/index.md
@@ -4,10 +4,22 @@ linkTitle: Developer Docs
 weight: 99
 ---
 
+## Architecture
+
+Kodit follows a layered architecture:
+
+- **`cmd/kodit/`** — CLI entry point with `serve` and `version` commands
+- **`kodit.go`** / **`options.go`** — Public library API (`kodit.New()`, `kodit.Client`)
+- **`application/`** — Application services and task handlers
+- **`domain/`** — Domain types (enrichment, repository, search, task)
+- **`infrastructure/`** — External integrations (API, database, git, providers, enrichers)
+- **`internal/`** — Internal packages (config, database, MCP, logging, testdb)
+- **`clients/go/`** — Generated Go HTTP client from OpenAPI spec
+
 ## Database
 
 All database operations are handled by GORM with AutoMigrate. There are no SQL migration
-files -- schema changes are applied automatically when the server starts.
+files — schema changes are applied automatically when the server starts.
 
 ### Making Schema Changes
 
@@ -25,11 +37,27 @@ make build
 # Run tests
 make test
 
+# Run tests for a specific package
+make test PKG=./internal/foo/...
+
+# Run all checks (format, vet, lint, test)
+make check
+
 # Run the smoke tests (requires Docker)
 make test-smoke
+```
 
-# Run the server locally
-make run
+## Documentation Generation
+
+```bash
+# Generate OpenAPI spec, Go client, API reference, and config reference
+make docs
+
+# Generate OpenAPI spec only
+make openapi
+
+# Generate Go client only
+make generate-clients
 ```
 
 ## Releasing
@@ -37,10 +65,9 @@ make run
 Performing a release is designed to be fully automated. If you spot opportunities to
 improve the CI to help performing an automated release, please do so.
 
-1. Create a new release in GitHub.
+1. Create a new release in GitHub (or use `make release BUMP=patch|minor|major RELEASE=1`).
 2. Set the version number. Use patch versions for bugfixes or minor small improvements.
    Use minor versions when adding significant new functionality. Use major versions for
    overhauls.
-3. Generate the release notes. <- this could be improved, because we use a strict
-   pr/commit naming structure.
+3. Generate the release notes.
 4. Wait for all jobs to succeed, then the Docker image will be published.

--- a/docs/getting-started/installation/index.md
+++ b/docs/getting-started/installation/index.md
@@ -4,12 +4,8 @@ description: How to install Kodit.
 weight: 1
 ---
 
-Unlike many MCP tools, Kodit is designed to run as a server. You're welcome to use the
-[public server](../_index.md), but if you want to index your own private repositories
-then you should deploy your own server.
-
-Kodit is a Go binary that hosts a REST API and an MCP server. Although most
-people deploy Kodit remotely in a container, you can also run it locally.
+Kodit is a Go binary that hosts a REST API and an MCP server. Most people deploy Kodit
+remotely in a container, but you can also run it locally.
 
 ## Docker
 
@@ -17,7 +13,7 @@ people deploy Kodit remotely in a container, you can also run it locally.
 docker run -it --rm -p 8080:8080 registry.helix.ml/helix/kodit:latest
 ```
 
-Always replace latest with a specific version.
+Always replace `latest` with a specific version.
 
 ## Pre-built Binaries
 
@@ -30,15 +26,19 @@ chmod +x kodit
 ./kodit serve
 ```
 
+## Embedding Model
+
+Kodit includes a built-in CPU-only embedding model for semantic search, so basic keyword
+and semantic search works out of the box with no external dependencies.
+
 ## Enrichment Model
 
-Kodit includes a built-in embedding model for semantic search, so basic keyword and
-semantic search works out of the box. However, to unlock AI-powered enrichments
-(architecture docs, API docs, database schemas, cookbook entries, and commit summaries),
-you need to configure an enrichment endpoint that points to an LLM provider.
+To unlock AI-powered enrichments (architecture docs, API docs, database schemas, cookbook
+entries, commit summaries, and wiki generation), you need to configure an enrichment
+endpoint that points to an LLM provider.
 
-Without an enrichment model, Kodit will index and search code but will not generate
-any AI summaries or documentation.
+Without an enrichment model, Kodit will index and search code but will not generate any AI
+documentation or summaries.
 
 Set the following environment variables to configure an enrichment provider:
 
@@ -50,6 +50,20 @@ ENRICHMENT_ENDPOINT_API_KEY=your-api-key
 
 See the [configuration reference](../../reference/configuration/index.md) for more
 provider examples including Ollama, Azure OpenAI, and other LiteLLM-compatible services.
+
+## Pipeline Presets
+
+Kodit supports two pipeline presets that control which operations run during indexing:
+
+- **Full pipeline** (default when an enrichment endpoint is configured): runs all operations
+  including LLM-powered enrichments (architecture docs, API docs, database schemas,
+  cookbooks, commit summaries, wiki generation)
+- **RAG-only pipeline**: runs snippet extraction, BM25 indexing, code embeddings, and
+  AST-based API docs. Skips all LLM enrichments. Useful when you only need search
+  without AI documentation.
+
+When no enrichment endpoint is configured, Kodit automatically runs a reduced pipeline
+equivalent to RAG-only.
 
 ## Next Steps
 

--- a/docs/getting-started/integration/index.md
+++ b/docs/getting-started/integration/index.md
@@ -13,7 +13,7 @@ Kodit runs an HTTP server that streams responses to connected AI coding assistan
 the `/mcp` endpoint.
 
 See the [MCP Reference](../../reference/mcp/index.md) for comprehensive integration
-instructions for popular coding assistants like Cursor, Claude, Cline, etc.
+instructions for popular coding assistants like Cursor, Claude Code, Cline, and Kilo Code.
 
 ### Local
 
@@ -30,5 +30,11 @@ instructions for popular coding assistants like Cursor, Claude, Cline, etc.
 
 ## HTTP API Connection Methods
 
-Helix also exposes a REST API with an `/api/v1/search` endpoint to allow integration
-with other tools. See the [Kodit HTTP API documentation](../../reference/api/index.md) for more information.
+Kodit also exposes a REST API with search, file browsing, and repository management
+endpoints. See the [API documentation](../../reference/api/index.md) for details.
+
+## Go SDK
+
+For programmatic access from Go applications, Kodit provides a library for direct
+embedding and a generated HTTP client for remote access. See the
+[Go SDK reference](../../reference/go-sdk/index.md) for details.

--- a/docs/getting-started/quick-start/index.md
+++ b/docs/getting-started/quick-start/index.md
@@ -35,8 +35,14 @@ curl http://localhost:8080/api/v1/repositories \
 curl http://localhost:8080/api/v1/repositories/1/status
 ```
 
-Wait for the indexing process to complete. If you see any errors at this stage, check
-your logs and consult the [troubleshooting guide](../reference/troubleshooting/index.md).
+Wait for the indexing process to complete. You can also check the aggregated summary:
+
+```sh
+curl http://localhost:8080/api/v1/repositories/1/status/summary
+```
+
+If you see any errors at this stage, check your logs and consult the
+[troubleshooting guide](../../reference/troubleshooting/index.md).
 
 ## 4. Search for Code
 
@@ -60,8 +66,37 @@ curl http://localhost:8080/api/v1/search \
 }'
 ```
 
-Check the API docs for more endpoints and examples.
+You can also use the keyword or semantic search endpoints directly:
 
-## 5. Integrate with your AI coding assistant
+```sh
+# Keyword search (BM25)
+curl "http://localhost:8080/api/v1/search/keyword?keywords=orders&limit=5"
+
+# Semantic search
+curl "http://localhost:8080/api/v1/search/semantic?query=get+all+orders&limit=5"
+
+# Grep (regex search via git grep)
+curl "http://localhost:8080/api/v1/search/grep?repository_id=1&pattern=GetAllOrders"
+
+# List files matching a pattern
+curl "http://localhost:8080/api/v1/search/ls?repository_id=1&pattern=**/*.go"
+```
+
+Check the [API docs](../../reference/api/index.md) for more endpoints and examples.
+
+## 5. Browse Enrichments
+
+If you configured an enrichment endpoint, Kodit generates AI-powered documentation for
+your repository. You can browse it via the API:
+
+```sh
+# List enrichments for the latest commit
+curl http://localhost:8080/api/v1/repositories/1/enrichments
+
+# View the wiki table of contents
+curl http://localhost:8080/api/v1/repositories/1/wiki
+```
+
+## 6. Integrate with your AI coding assistant
 
 Now [add the Kodit MCP server to your AI coding assistant](../integration/index.md).

--- a/docs/reference/indexing/index.md
+++ b/docs/reference/indexing/index.md
@@ -4,17 +4,52 @@ description: Learn how to index Git repositories in Kodit for AI-powered code se
 weight: 1
 ---
 
-Kodit indexes Git repositories to create searchable code databases for AI assistants. The system splits source files into fixed-size text chunks and builds multiple search indexes for different query types.
+Kodit indexes Git repositories to create searchable code databases for AI assistants. The
+system splits source files into fixed-size text chunks, builds multiple search indexes,
+and optionally generates AI-powered documentation.
 
 ## How Indexing Works
 
-Kodit transforms Git repositories through a 5-stage pipeline:
+Kodit transforms Git repositories through a multi-stage pipeline:
 
 1. **Clone Repository**: Downloads the Git repository locally
 2. **Scan Repository**: Extracts Git metadata (commits, branches, tags)
 3. **Chunk Files**: Splits source files into fixed-size, overlapping text chunks
-4. **Build Indexes**: Creates BM25 (keyword), code embeddings (semantic), and text embeddings (natural language) indexes
-5. **AI Enrichment**: Generates summaries using LLM providers for enhanced search
+4. **Build Search Indexes**: Creates BM25 (keyword), code embeddings (semantic), and text embeddings (natural language) indexes
+5. **AI Enrichment** (requires an enrichment endpoint): Generates documentation using an LLM provider
+
+### Enrichment Types
+
+When an enrichment endpoint is configured, Kodit generates the following for each commit:
+
+| Type | Subtype | Description |
+|------|---------|-------------|
+| Architecture | Physical | High-level architecture documentation |
+| Architecture | Database Schema | Database schema documentation |
+| Development | Snippet | Code snippets with context |
+| Development | Snippet Summary | AI-generated summaries of code snippets |
+| Development | Example | Usage examples extracted from code |
+| Development | Chunk | Raw text chunks |
+| History | Commit Description | AI-generated commit summaries |
+| Usage | API Docs | API and interface documentation (AST-based, no LLM required) |
+| Usage | Cookbook | Cookbook entries with usage examples |
+| Usage | Wiki | Structured wiki pages covering architecture, APIs, data models, and more |
+
+### Pipeline Presets
+
+Kodit supports two pipeline presets:
+
+- **Full pipeline** (default when an enrichment endpoint is configured): runs all
+  operations including LLM-powered enrichments
+- **RAG-only pipeline**: runs snippet extraction, BM25 indexing, code embeddings, and
+  AST-based API docs. Skips LLM enrichments. Useful for lightweight search without AI
+  documentation generation.
+
+When no enrichment endpoint is configured, Kodit automatically disables LLM-dependent
+operations.
+
+For the Go SDK, use `kodit.WithRAGPipeline()` or `kodit.WithFullPipeline()` to select a
+preset explicitly.
 
 ### Supported Sources
 
@@ -28,12 +63,12 @@ Supports GitHub, GitLab, Bitbucket, Azure DevOps, and self-hosted Git servers.
 
 ## REST API
 
-Kodit provides a REST API that allows you to programmatically manage indexes and search
-code snippets. The API is automatically available when you start the Kodit server and
+Kodit provides a REST API that allows you to programmatically manage repositories and
+search code. The API is automatically available when you start the Kodit server and
 follows the JSON:API specification for consistent request/response formats.
 
-Please see the [API documentation](../api/index.md) for a full description of the API. You can also
-browse to the live API documentation by visiting `/docs`.
+Please see the [API documentation](../api/index.md) for a full description. You can also
+browse the live API documentation by visiting `/docs`.
 
 ## Authentication
 
@@ -47,7 +82,8 @@ git@github.com:username/repo.git
 
 ## Supported Languages
 
-20+ programming languages including Python, JavaScript/TypeScript, Java, Go, Rust, C/C++, C#, HTML/CSS, and more.
+20+ programming languages including Python, JavaScript/TypeScript, Java, Go, Rust, C/C++,
+C#, HTML/CSS, and more.
 
 ## Advanced Features
 
@@ -58,20 +94,77 @@ git@github.com:username/repo.git
 - Bulk operations for performance
 - Concurrent file chunking
 
+### Branch Tracking
+
+Each repository has a configurable tracking configuration that controls which branch is
+indexed. By default, Kodit tracks the repository's default branch. You can update the
+tracking configuration via the API:
+
+```sh
+curl http://localhost:8080/api/v1/repositories/1/tracking-config \
+-X PUT \
+-H "Content-Type: application/json" \
+-d '{
+  "data": {
+    "type": "tracking_config",
+    "attributes": {
+      "mode": "branch",
+      "value": "develop"
+    }
+  }
+}'
+```
+
 ### Task Queue System
 
-- User-initiated (high priority)
+- User-initiated operations (high priority)
 - Background sync (low priority)
 - Repository and commit operations
 - Automatic retry with backoff
 
-### Auto-Sync Server
+### Auto-Sync
 
-- 30-minute default sync intervals
+- 30-minute default sync intervals (configurable)
 - Background processing
 - Incremental updates only
+- See the [sync reference](../sync/index.md) for details
+
+### Wiki Generation
+
+When an enrichment endpoint is configured, Kodit generates a structured wiki for each
+repository. The wiki provides hierarchical documentation pages and can be browsed via the
+API or through MCP tools.
+
+```sh
+# View wiki table of contents
+curl http://localhost:8080/api/v1/repositories/1/wiki
+
+# View a specific wiki page
+curl http://localhost:8080/api/v1/repositories/1/wiki/architecture/overview.md
+
+# Regenerate the wiki
+curl -X POST http://localhost:8080/api/v1/repositories/1/wiki/rescan
+```
+
+### File Browsing
+
+Kodit provides direct access to repository files without needing a local clone:
+
+```sh
+# Read a file at a specific commit/branch/tag
+curl "http://localhost:8080/api/v1/repositories/1/blob/main/src/main.go?line_numbers=true"
+
+# Read specific lines
+curl "http://localhost:8080/api/v1/repositories/1/blob/main/src/main.go?lines=L17-L26"
+
+# Grep for patterns
+curl "http://localhost:8080/api/v1/search/grep?repository_id=1&pattern=func.*Handler"
+
+# List files
+curl "http://localhost:8080/api/v1/search/ls?repository_id=1&pattern=**/*.go"
+```
 
 ## Configuration
 
-Please see the [configuration reference](/kodit/reference/configuration/index.md) for
-full details and examples.
+Please see the [configuration reference](../configuration/index.md) for full details
+and examples.

--- a/docs/reference/mcp/index.md
+++ b/docs/reference/mcp/index.md
@@ -7,9 +7,8 @@ weight: 2
 The [Model Context Protocol](https://modelcontextprotocol.io/introduction) (MCP) is a
 standard that enables AI assistants to communicate with external tools and data sources.
 
-Kodit provides an MCP (Model Context Protocol) server that enables AI coding assistants
-to search and retrieve relevant code snippets from your indexed codebases. This allows
-AI assistants to provide more accurate and contextually relevant code suggestions.
+Kodit provides an MCP server that enables AI coding assistants to search, browse, and
+retrieve relevant code and documentation from your indexed codebases.
 
 ## MCP Server Connection
 
@@ -91,7 +90,7 @@ Add the following configuration:
 ### Integration With Kilo Code
 
 1. Open Kilo Code from the side menu
-2. Click the `MCP Servers` button at the top right of the Cline window (the icon looks
+2. Click the `MCP Servers` button at the top right of the Kilo Code window (the icon looks
    like a server)
 3. Click the `Edit Project/Global MCP` button.
 
@@ -122,7 +121,6 @@ settings.
 Try using this system prompt:
 
 ```txt
-⚠️ **ENFORCEMENT:**
 For *every* user request that involves writing or modifying code (of any language or
 domain), the assistant's *first* action **must** be to call the kodit.search MCP tool.
 You may only produce or edit code *after* that tool call and its successful
@@ -139,7 +137,6 @@ Add the following prompt to `.cursor/rules/kodit.mdc` in your project directory:
 ---
 alwaysApply: true
 ---
-⚠️ **ENFORCEMENT:**
 For *every* user request that involves writing or modifying code (of any language or
 domain), the assistant's *first* action **must** be to call the kodit.search MCP tool.
 You may only produce or edit code *after* that tool call and its successful
@@ -161,55 +158,61 @@ The Kodit MCP server exposes the following tools to AI coding assistants:
 
 | Tool | Description |
 |------|-------------|
-| `kodit_repositories` | List all indexed repositories. Call this first to discover available repos. |
-| `kodit_version` | Get the Kodit server version. |
+| `kodit_version` | Get the Kodit server version |
+| `kodit_repositories` | List all indexed repositories. Call this first to discover available repos |
 
 ### Repository Knowledge Tools
 
+These tools retrieve AI-generated documentation for a repository. They require a
+`repo_url` parameter (the remote URL of the repository) and accept an optional
+`commit_sha` to pin to a specific commit (defaults to latest).
+
 | Tool | Description |
 |------|-------------|
-| `kodit_architecture_docs` | Get high-level architecture documentation for a repository. |
-| `kodit_api_docs` | Get API/interface documentation for a repository. |
-| `kodit_database_schema` | Get database schema documentation for a repository. |
-| `kodit_cookbook` | Get usage examples and cookbook entries for a repository. |
-| `kodit_commit_description` | Get the description of a specific commit. |
+| `kodit_architecture_docs` | High-level architecture documentation |
+| `kodit_api_docs` | API and interface documentation |
+| `kodit_database_schema` | Database schema documentation |
+| `kodit_cookbook` | Usage examples and cookbook entries |
+| `kodit_commit_description` | Description and summary of a specific commit |
 
-### Search Tool
+### Wiki Tools
 
-The `search` tool provides comprehensive code search capabilities.
+Kodit generates a structured wiki for each repository. The wiki provides hierarchical
+documentation pages covering architecture, APIs, data models, and more.
 
-#### Search Parameters
+| Tool | Description |
+|------|-------------|
+| `kodit_wiki` | Get the table of contents for a repository's wiki. Parameters: `repo_url` (required), `commit_sha` (optional) |
+| `kodit_wiki_page` | Get the content of a specific wiki page. Parameters: `repo_url` (required), `page_slug` (required), `commit_sha` (optional) |
 
-| Parameter | Type | Description | Example |
-|-----------|------|-------------|---------|
-| `user_intent` | string | Description of what the user wants to achieve | "Create a REST API endpoint for user authentication" |
-| `related_file_paths` | list[string] | Absolute paths to relevant files | `["/path/to/auth.go"]` |
-| `related_file_contents` | list[string] | Contents of relevant files | `["func authenticate() ..."]` |
-| `keywords` | list[string] | Relevant keywords for the search | `["authentication", "jwt", "login"]` |
-| `language` | string \| null | Filter by programming language (20+ supported) | `"python"`, `"go"`, `"javascript"`, `"html"`, `"css"` |
-| `author` | string \| null | Filter by author name | `"john.doe"` |
-| `created_after` | string \| null | Filter by creation date (YYYY-MM-DD) | `"2023-01-01"` |
-| `created_before` | string \| null | Filter by creation date (YYYY-MM-DD) | `"2023-12-31"` |
-| `source_repo` | string \| null | Filter by source repository | `"github.com/example/repo"` |
-| `enrichment_subtypes` | list[string] \| null | Filter by enrichment subtypes | `["snippet", "example"]` |
+### Search Tools
 
-#### Advanced Search Functionality
+Search tools return file resource URIs that can be read with `kodit_read_resource`.
 
-The search tool combines multiple search strategies with sophisticated ranking:
+| Tool | Description |
+|------|-------------|
+| `kodit_semantic_search` | Semantic similarity search. Parameters: `query` (required), `language`, `source_repo`, `limit` |
+| `kodit_keyword_search` | BM25 keyword search. Parameters: `keywords` (required), `source_repo`, `language`, `limit` |
 
-1. **BM25 Keyword Search** - Advanced keyword matching with relevance scoring
-2. **Semantic Code Search** - Uses embeddings to find semantically similar code patterns
-3. **Semantic Text Search** - Uses embeddings to find code matching natural language descriptions
-4. **Reciprocal Rank Fusion (RRF)** - Intelligently combines results from multiple search strategies
-5. **Context-Aware Filtering** - Advanced filtering by language, author, date, source, and file path
-6. **AI-Enriched Results** - Returns code chunks with LLM-generated summaries
+### File Browsing Tools
 
-#### Enhanced Result Quality
+| Tool | Description |
+|------|-------------|
+| `kodit_grep` | Regex search via git grep. Parameters: `repo_url` (required), `pattern` (required), `glob`, `limit` |
+| `kodit_ls` | List files matching a glob pattern. Parameters: `repo_url` (required), `pattern` (required) |
+| `kodit_read_resource` | Read file contents from a resource URI returned by search, grep, or ls. Parameters: `uri` (required) |
 
-- **Smart Chunk Selection**: Returns relevant code chunks with context
-- **Rich Metadata**: Each result includes file path, language, author, and creation date
-- **Usage Examples**: Includes examples of how functions are used in the codebase
-- **Topological Ordering**: Dependencies are ordered for optimal LLM consumption
+### Resource URI Format
+
+Search, grep, and ls tools return file resource URIs in the format:
+
+```
+file://{repo_id}/{ref}/{path}?lines=L17-L26&line_numbers=true
+```
+
+Use `kodit_read_resource` to fetch the content of these URIs. The `lines` parameter
+supports ranges like `L17-L26,L45,L55-L90` and `line_numbers=true` prefixes each line
+with its 1-based line number.
 
 ## Filtering Capabilities
 
@@ -222,9 +225,6 @@ Filter results by programming language:
 **Example prompts:**
 > "I need to create a web server in Python. Please search for Flask or FastAPI examples and show me the best practices."
 > "I'm working on a Go microservice. Can you search for Go-specific patterns for handling HTTP requests and database connections?"
-> "I need JavaScript examples for form validation. Please search for modern JavaScript/TypeScript validation patterns."
-> "I'm building a responsive layout. Please search for CSS Grid and Flexbox examples in our stylesheets."
-> "I need HTML form examples. Please search for form elements with proper accessibility attributes."
 
 ### Author Filtering
 
@@ -232,15 +232,13 @@ Filter results by code author:
 
 **Example prompts:**
 > "I'm reviewing code written by john.doe. Can you search for their authentication implementations to understand their coding style?"
-> "I need to find all the database-related code written by alice.smith. Please search for her database connection and query patterns."
 
 ### Date Range Filtering
 
 Filter results by creation date:
 
 **Example prompts:**
-> "I need to see authentication patterns from 2023. Please search for JWT and OAuth implementations created in 2023."
-> "Show me modern React patterns from the last year. Search for React components and hooks created after 2023."
+> "I need to see authentication patterns from 2025. Please search for JWT and OAuth implementations created in 2025."
 
 ### Source Repository Filtering
 
@@ -248,89 +246,50 @@ Filter results by source repository:
 
 **Example prompts:**
 > "I'm working on the auth-service project. Please search for authentication patterns specifically from github.com/company/auth-service."
-> "I need to understand how the user-service handles user management. Search for user-related code from github.com/company/user-service."
 
 ### Combining Filters
 
 You can combine multiple filters for precise results:
 
 **Example prompts:**
-> "I need Python authentication code written by alice.smith in 2023 from the auth-service repository. Please search for JWT token validation patterns."
-> "Show me Go microservice patterns from john.doe created in 2023 from the backend-services repository."
-> "I'm looking for modern React patterns from the frontend team (search for authors: alice.smith, bob.jones) created in 2024 from the web-app repository."
+> "I need Python authentication code written by alice.smith in 2025 from the auth-service repository."
 
 ## AI Assistant Integration Tips
 
-To get the best results from Kodit with your AI assistant, follow these prompting strategies:
-
 ### 1. Provide Clear User Intent
-
-When the AI assistant calls the search tool, ensure it provides a clear, descriptive `user_intent`:
 
 **Good examples:**
 
 - "Create a REST API endpoint for user authentication with JWT tokens"
 - "Implement a database connection pool for PostgreSQL"
-- "Write a function to validate email addresses using regex"
 
 **Poor examples:**
 
 - "Help me with auth"
 - "Database stuff"
-- "Email validation"
 
 ### 2. Use Relevant Keywords
 
-Provide specific, technical keywords that are relevant to your task, where applicable.
-Remember that the language model is more than capable of generating appropriate keywords
-for your intent.
-
-**Good examples:**
-
-- `["authentication", "jwt", "login", "password"]`
-- `["database", "postgresql", "connection", "pool"]`
-- `["email", "validation", "regex", "format"]`
+Provide specific, technical keywords that are relevant to your task. The language model
+is more than capable of generating appropriate keywords for your intent.
 
 ### 3. Leverage File Context
 
 If you're working with existing files, mention them in your prompt:
 
-**Example prompts:**
-> "I'm working on the authentication function in auth.go. Can you search for similar error handling patterns and show me how to improve the error handling in my existing code?"
-> "I have a database connection setup in database.go. Please search for connection pooling patterns and show me how to optimize my current implementation."
+> "I'm working on the authentication function in auth.go. Can you search for similar error handling patterns?"
 
 ### 4. Use Language Filtering
 
 Specify the programming language in your prompt:
 
-**Example prompts:**
-> "I need to create a web server in Python. Please search for Flask and FastAPI examples and show me the best practices."
-> "I'm building a Go microservice. Can you search for Go-specific patterns for handling HTTP requests and database connections?"
-> "I need JavaScript examples for form validation. Please search for modern JavaScript/TypeScript validation patterns."
+> "I need to create a web server in Python. Please search for Flask and FastAPI examples."
 
 ### 5. Filter by Source Repository
 
 If you have multiple codebases indexed, mention the specific repository:
 
-**Example prompts:**
-> "I'm working on the user-service project. Please search for user management patterns specifically from github.com/company/user-service."
-> "I need to understand how the auth-service handles authentication. Search for auth-related code from github.com/company/auth-service."
-
-### 6. Example Prompts for AI Assistants
-
-Here are some example prompts you can use with your AI assistant:
-
-**For new code development:**
-> "I want to create a new Python web API. Please search for examples of Flask/FastAPI authentication patterns and show me the best practices."
-
-**For debugging existing code:**
-> "I'm having issues with this database connection code. Can you search for similar patterns and show me how others handle connection errors?"
-
-**For learning new patterns:**
-> "I need to implement JWT authentication in Go. Please search for production-ready examples and show me the security best practices."
-
-**For code review:**
-> "I'm reviewing this authentication function. Can you search for similar implementations and show me potential security issues or improvements?"
+> "Search for user management patterns from github.com/company/user-service."
 
 ## Troubleshooting
 

--- a/docs/reference/sync/index.md
+++ b/docs/reference/sync/index.md
@@ -63,8 +63,19 @@ If you prefer to sync manually:
 PERIODIC_SYNC_ENABLED=false
 ```
 
+## Manual Sync
+
+You can also trigger a manual sync for a specific repository via the API:
+
+```sh
+curl -X POST http://localhost:8080/api/v1/repositories/1/sync
+```
+
+This enqueues a sync task (git fetch + branch scan + commit indexing) and returns
+immediately with a `202 Accepted` status.
+
 ## Limitations
 
-- **Only syncs existing indexes**: The sync scheduler does not create new indexes for repositories that haven't been indexed yet
-- **Sequential processing**: Indexes are synced one at a time to avoid overwhelming the system
+- **Only syncs existing repositories**: The sync scheduler does not create new indexes for repositories that haven't been added yet
+- **Sequential processing**: Repositories are synced one at a time to avoid overwhelming the system
 - **No conflict resolution**: If there are conflicts during sync, the operation may fail and require manual intervention

--- a/docs/reference/troubleshooting/index.md
+++ b/docs/reference/troubleshooting/index.md
@@ -7,3 +7,31 @@ weight: 90
 ## MCP Troubleshooting
 
 - `Error POSTing to endpoint (HTTP 400): Bad Request: No valid session ID provided`: This happens after Kodit server restarts. Reload your MCP client.
+
+## Indexing Troubleshooting
+
+- **Indexing appears stuck**: Check the task queue status at `/api/v1/queue` and the
+  repository status at `/api/v1/repositories/{id}/status/summary`. Enable debug logging
+  with `LOG_LEVEL=DEBUG` for more detail.
+- **No enrichments generated**: Ensure an enrichment endpoint is configured. Without
+  `ENRICHMENT_ENDPOINT_*` environment variables, Kodit only performs basic indexing
+  (chunking, BM25, and embeddings) without AI-powered documentation.
+- **Private repository access fails**: Ensure the repository URL includes authentication
+  credentials (e.g. `https://user:token@github.com/org/repo.git`) or that SSH keys are
+  configured for SSH URLs.
+
+## Search Troubleshooting
+
+- **No search results**: Verify that indexing has completed by checking the repository
+  status. Results only appear after the indexing pipeline finishes.
+- **Semantic search returns poor results**: The built-in embedding model is small and
+  optimised for code search. For better semantic search quality, configure an external
+  embedding provider via `EMBEDDING_ENDPOINT_*` environment variables.
+
+## Debug Logging
+
+Enable debug logging for detailed diagnostics:
+
+```sh
+LOG_LEVEL=DEBUG kodit serve
+```


### PR DESCRIPTION
## Summary

Updated all documentation to accurately reflect the current state of the codebase, including all recently added features and MCP tools.

### Changes

- **README.md**: Complete rewrite including all 14 MCP tools, Go SDK section, pipeline presets, built-in embedding model, and Anthropic support
- **docs/_index.md**: Updated landing page, fixed copyright year to 2026
- **Getting Started guides**: Added pipeline presets, expanded quick start examples, clarified requirements
- **MCP Reference**: Major rewrite with complete tool listing (was missing 7 tools), wiki and file browsing documentation
- **Indexing Reference**: Added enrichment types table, pipeline presets, branch tracking, wiki generation, file browsing API
- **Sync Reference**: Added manual sync API endpoint
- **Demo Pages**: Fixed to use current `/api/v1/repositories` endpoint (was using deprecated `/api/v1/indexes`)
- **Troubleshooting**: Expanded with new sections
- **Developer Docs**: Added architecture overview

### Details

- 14 files changed
- +462 / -246 lines
- All demos updated to use current API
- All copyright years updated to 2026