### PR TITLE
Extract images from Office documents (docx/pptx/xlsx)

### DIFF
--- a/infrastructure/rasterization/office.go
+++ b/infrastructure/rasterization/office.go
@@ -1,0 +1,131 @@
+package rasterization
+
+import (
+	"archive/zip"
+	"fmt"
+	"image"
+	// Register standard image decoders.
+	_ "image/gif"
+	_ "image/jpeg"
+	_ "image/png"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	_ "golang.org/x/image/bmp"
+	_ "golang.org/x/image/tiff"
+)
+
+// mediaPrefixes are the ZIP directory prefixes where Office Open XML
+// formats store embedded media files.
+var mediaPrefixes = []string{
+	"word/media/",
+	"ppt/media/",
+	"xl/media/",
+}
+
+// supportedImageExts lists extensions that Go's image package can decode
+// (with the registered imports above).
+var supportedImageExts = map[string]bool{
+	".png":  true,
+	".jpg":  true,
+	".jpeg": true,
+	".gif":  true,
+	".bmp":  true,
+	".tiff": true,
+	".tif":  true,
+}
+
+// OfficeImageExtractor extracts embedded images from Office Open XML
+// documents (docx, pptx, xlsx). These formats are ZIP archives with
+// media files at predictable paths.
+type OfficeImageExtractor struct{}
+
+// NewOfficeImageExtractor creates an OfficeImageExtractor.
+func NewOfficeImageExtractor() *OfficeImageExtractor {
+	return &OfficeImageExtractor{}
+}
+
+// PageCount returns the number of extractable images in the document.
+func (o *OfficeImageExtractor) PageCount(path string) (int, error) {
+	names, err := mediaImageNames(path)
+	if err != nil {
+		return 0, err
+	}
+	return len(names), nil
+}
+
+// Render returns the Nth (1-based) embedded image as an image.Image.
+func (o *OfficeImageExtractor) Render(path string, page int) (image.Image, error) {
+	names, err := mediaImageNames(path)
+	if err != nil {
+		return nil, err
+	}
+
+	if page < 1 || page > len(names) {
+		return nil, fmt.Errorf("page %d out of range [1, %d]", page, len(names))
+	}
+
+	target := names[page-1]
+
+	r, err := zip.OpenReader(path)
+	if err != nil {
+		return nil, fmt.Errorf("open zip %s: %w", path, err)
+	}
+	defer r.Close()
+
+	for _, f := range r.File {
+		if f.Name != target {
+			continue
+		}
+		rc, openErr := f.Open()
+		if openErr != nil {
+			return nil, fmt.Errorf("open %s: %w", f.Name, openErr)
+		}
+		defer rc.Close()
+
+		img, _, decodeErr := image.Decode(rc)
+		if decodeErr != nil {
+			return nil, fmt.Errorf("decode %s: %w", f.Name, decodeErr)
+		}
+		return img, nil
+	}
+
+	return nil, fmt.Errorf("entry %s not found in %s", target, path)
+}
+
+// Close is a no-op — OfficeImageExtractor holds no persistent state.
+func (o *OfficeImageExtractor) Close() error { return nil }
+
+// mediaImageNames opens the ZIP archive and returns the sorted names
+// of image entries found under Office media directories.
+func mediaImageNames(path string) ([]string, error) {
+	r, err := zip.OpenReader(path)
+	if err != nil {
+		return nil, fmt.Errorf("open zip %s: %w", path, err)
+	}
+	defer r.Close()
+
+	var names []string
+	for _, f := range r.File {
+		if isMediaImage(f.Name) {
+			names = append(names, f.Name)
+		}
+	}
+
+	sort.Strings(names)
+	return names, nil
+}
+
+// isMediaImage returns true if the ZIP entry path is an image file
+// inside one of the standard Office media directories.
+func isMediaImage(name string) bool {
+	lower := strings.ToLower(name)
+	for _, prefix := range mediaPrefixes {
+		if strings.HasPrefix(lower, prefix) {
+			ext := strings.ToLower(filepath.Ext(name))
+			return supportedImageExts[ext]
+		}
+	}
+	return false
+}

--- a/infrastructure/rasterization/office.go
+++ b/infrastructure/rasterization/office.go
@@ -72,7 +72,7 @@ func (o *OfficeImageExtractor) Render(path string, page int) (image.Image, error
 	if err != nil {
 		return nil, fmt.Errorf("open zip %s: %w", path, err)
 	}
-	defer r.Close()
+	defer func() { _ = r.Close() }()
 
 	for _, f := range r.File {
 		if f.Name != target {
@@ -82,7 +82,7 @@ func (o *OfficeImageExtractor) Render(path string, page int) (image.Image, error
 		if openErr != nil {
 			return nil, fmt.Errorf("open %s: %w", f.Name, openErr)
 		}
-		defer rc.Close()
+		defer func() { _ = rc.Close() }()
 
 		img, _, decodeErr := image.Decode(rc)
 		if decodeErr != nil {
@@ -104,7 +104,7 @@ func mediaImageNames(path string) ([]string, error) {
 	if err != nil {
 		return nil, fmt.Errorf("open zip %s: %w", path, err)
 	}
-	defer r.Close()
+	defer func() { _ = r.Close() }()
 
 	var names []string
 	for _, f := range r.File {

--- a/infrastructure/rasterization/office_test.go
+++ b/infrastructure/rasterization/office_test.go
@@ -1,0 +1,201 @@
+package rasterization
+
+import (
+	"archive/zip"
+	"image"
+	"image/color"
+	"image/png"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// writeTestOffice creates a minimal ZIP file (simulating an Office Open XML
+// document) with the given entries. Each entry maps a ZIP path to raw bytes.
+func writeTestOffice(t *testing.T, name string, entries map[string][]byte) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), name)
+	f, err := os.Create(path)
+	require.NoError(t, err)
+
+	w := zip.NewWriter(f)
+	for k, v := range entries {
+		fw, werr := w.Create(k)
+		require.NoError(t, werr)
+		_, werr = fw.Write(v)
+		require.NoError(t, werr)
+	}
+	require.NoError(t, w.Close())
+	require.NoError(t, f.Close())
+	return path
+}
+
+// redPNG returns a 2x2 red PNG image as raw bytes.
+func redPNG(t *testing.T) []byte {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, 2, 2))
+	for y := 0; y < 2; y++ {
+		for x := 0; x < 2; x++ {
+			img.Set(x, y, color.RGBA{R: 255, A: 255})
+		}
+	}
+	var buf []byte
+	w := &sliceWriter{buf: &buf}
+	require.NoError(t, png.Encode(w, img))
+	return buf
+}
+
+type sliceWriter struct{ buf *[]byte }
+
+func (s *sliceWriter) Write(p []byte) (int, error) {
+	*s.buf = append(*s.buf, p...)
+	return len(p), nil
+}
+
+func TestOfficeImageExtractor_PageCount(t *testing.T) {
+	img := redPNG(t)
+	path := writeTestOffice(t, "slides.pptx", map[string][]byte{
+		"ppt/media/image1.png":  img,
+		"ppt/media/image2.png":  img,
+		"ppt/media/image3.jpeg": img, // wrong extension for content, but counts
+		"ppt/slides/slide1.xml": []byte("<xml/>"),
+		"ppt/media/chart1.emf":  []byte("not an image"), // unsupported ext
+	})
+
+	ext := NewOfficeImageExtractor()
+	count, err := ext.PageCount(path)
+	require.NoError(t, err)
+	require.Equal(t, 3, count) // image1.png, image2.png, image3.jpeg — emf excluded
+}
+
+func TestOfficeImageExtractor_PageCount_Docx(t *testing.T) {
+	img := redPNG(t)
+	path := writeTestOffice(t, "doc.docx", map[string][]byte{
+		"word/media/photo.png": img,
+		"word/document.xml":    []byte("<xml/>"),
+	})
+
+	ext := NewOfficeImageExtractor()
+	count, err := ext.PageCount(path)
+	require.NoError(t, err)
+	require.Equal(t, 1, count)
+}
+
+func TestOfficeImageExtractor_PageCount_Xlsx(t *testing.T) {
+	img := redPNG(t)
+	path := writeTestOffice(t, "sheet.xlsx", map[string][]byte{
+		"xl/media/logo.png":   img,
+		"xl/media/chart.jpg":  img,
+		"xl/worksheets/s.xml": []byte("<xml/>"),
+	})
+
+	ext := NewOfficeImageExtractor()
+	count, err := ext.PageCount(path)
+	require.NoError(t, err)
+	require.Equal(t, 2, count)
+}
+
+func TestOfficeImageExtractor_PageCount_NoImages(t *testing.T) {
+	path := writeTestOffice(t, "empty.docx", map[string][]byte{
+		"word/document.xml": []byte("<xml/>"),
+	})
+
+	ext := NewOfficeImageExtractor()
+	count, err := ext.PageCount(path)
+	require.NoError(t, err)
+	require.Equal(t, 0, count)
+}
+
+func TestOfficeImageExtractor_Render(t *testing.T) {
+	img := redPNG(t)
+	path := writeTestOffice(t, "slides.pptx", map[string][]byte{
+		"ppt/media/image1.png": img,
+		"ppt/media/image2.png": img,
+	})
+
+	ext := NewOfficeImageExtractor()
+	result, err := ext.Render(path, 1)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	bounds := result.Bounds()
+	require.Equal(t, 2, bounds.Dx())
+	require.Equal(t, 2, bounds.Dy())
+
+	// Verify the pixel is red.
+	r, g, b, a := result.At(0, 0).RGBA()
+	require.Equal(t, uint32(0xffff), r)
+	require.Equal(t, uint32(0), g)
+	require.Equal(t, uint32(0), b)
+	require.Equal(t, uint32(0xffff), a)
+}
+
+func TestOfficeImageExtractor_Render_Deterministic(t *testing.T) {
+	img := redPNG(t)
+	path := writeTestOffice(t, "slides.pptx", map[string][]byte{
+		"ppt/media/b_second.png": img,
+		"ppt/media/a_first.png":  img,
+	})
+
+	ext := NewOfficeImageExtractor()
+
+	// Pages are sorted by path — a_first comes before b_second.
+	r1, err := ext.Render(path, 1)
+	require.NoError(t, err)
+	r2, err := ext.Render(path, 2)
+	require.NoError(t, err)
+	require.NotNil(t, r1)
+	require.NotNil(t, r2)
+}
+
+func TestOfficeImageExtractor_Render_OutOfRange(t *testing.T) {
+	img := redPNG(t)
+	path := writeTestOffice(t, "slides.pptx", map[string][]byte{
+		"ppt/media/image1.png": img,
+	})
+
+	ext := NewOfficeImageExtractor()
+
+	_, err := ext.Render(path, 0)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "out of range")
+
+	_, err = ext.Render(path, 2)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "out of range")
+}
+
+func TestOfficeImageExtractor_NotAZip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "notazip.docx")
+	require.NoError(t, os.WriteFile(path, []byte("not a zip file"), 0o644))
+
+	ext := NewOfficeImageExtractor()
+
+	_, err := ext.PageCount(path)
+	require.Error(t, err)
+
+	_, err = ext.Render(path, 1)
+	require.Error(t, err)
+}
+
+func TestOfficeImageExtractor_EMFExcluded(t *testing.T) {
+	img := redPNG(t)
+	path := writeTestOffice(t, "slides.pptx", map[string][]byte{
+		"ppt/media/image1.png":  img,
+		"ppt/media/vector.emf":  []byte("emf data"),
+		"ppt/media/vector2.wmf": []byte("wmf data"),
+		"ppt/media/icon.svg":    []byte("<svg/>"),
+	})
+
+	ext := NewOfficeImageExtractor()
+	count, err := ext.PageCount(path)
+	require.NoError(t, err)
+	require.Equal(t, 1, count) // only image1.png
+}
+
+func TestOfficeImageExtractor_Close(t *testing.T) {
+	ext := NewOfficeImageExtractor()
+	require.NoError(t, ext.Close())
+}

--- a/kodit.go
+++ b/kodit.go
@@ -434,6 +434,11 @@ func New(opts ...Option) (*Client, error) {
 		logger.Warn().Msg("PDF rasterizer not available — page image extraction will skip PDF files")
 	}
 
+	officeRast := rasterization.NewOfficeImageExtractor()
+	for _, ext := range []string{".docx", ".pptx", ".xlsx"} {
+		rasterizers.Register(ext, officeRast)
+	}
+
 	// Create enrichment infrastructure (always available)
 	archDiscoverer := enricher.NewPhysicalArchitectureService()
 	schemaDiscoverer := enricher.NewDatabaseSchemaService()


### PR DESCRIPTION
## Summary
Add image extraction from Office Open XML documents by implementing a new `OfficeImageExtractor` that plugs into the existing rasterization registry. This enables vision search over images embedded in Word, PowerPoint, and Excel files.

## Changes
- New `infrastructure/rasterization/office.go` — walks ZIP archives to find and decode embedded images from `word/media/`, `ppt/media/`, `xl/media/` directories
- Register `.docx`, `.pptx`, `.xlsx` extensions in the rasterizer registry (`kodit.go`)
- 10 unit tests covering page count, rendering, deterministic ordering, out-of-range errors, unsupported formats (EMF/WMF/SVG), and invalid input

## Testing
- All 15 rasterization tests pass (`make test PKG=./infrastructure/rasterization/...`)
- `go vet` clean
- No new pipeline operations or handlers — reuses existing `ExtractPageImages` and `CreatePageImageEmbeddings` handlers unchanged

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01km00txafwfd22yqdzvkcd5ar/tasks/spt_01knq8n00d936yrt0tqbnea1te)

📋 Spec:
- [Requirements](https://github.com/helixml/kodit/blob/helix-specs/design/tasks/001745_please-implement-a-new/requirements.md)
- [Design](https://github.com/helixml/kodit/blob/helix-specs/design/tasks/001745_please-implement-a-new/design.md)
- [Tasks](https://github.com/helixml/kodit/blob/helix-specs/design/tasks/001745_please-implement-a-new/tasks.md)

🚀 Built with [Helix](https://helix.ml)