### PR TITLE
feat: index standalone image files and add path traversal guard

### DIFF
--- a/application/handler/indexing/chunk_files.go
+++ b/application/handler/indexing/chunk_files.go
@@ -150,7 +150,12 @@ func (h *ChunkFiles) Execute(ctx context.Context, payload map[string]any) error 
 				processed++
 				continue
 			}
-			diskPath := filepath.Join(clonedPath, relPath)
+			diskPath, safe := safeDiskPath(clonedPath, relPath)
+			if !safe {
+				h.logger.Warn().Str("path", f.Path()).Msg("file path escapes clone directory, skipping")
+				processed++
+				continue
+			}
 			var extractErr error
 			text, extractErr = h.documentText.Text(diskPath)
 			if extractErr != nil {
@@ -259,6 +264,18 @@ func relativeFilePath(filePath, clonedPath string) string {
 	}
 
 	return filePath
+}
+
+// safeDiskPath joins clonedPath and relPath and verifies the result stays
+// inside clonedPath. Returns ("", false) if the resolved path escapes.
+func safeDiskPath(clonedPath, relPath string) (string, bool) {
+	diskPath := filepath.Join(clonedPath, relPath)
+	clean := filepath.Clean(diskPath)
+	base := filepath.Clean(clonedPath) + string(filepath.Separator)
+	if !strings.HasPrefix(clean, base) && clean != filepath.Clean(clonedPath) {
+		return "", false
+	}
+	return clean, true
 }
 
 // indexableExtensions lists file extensions that contain human-written source

--- a/application/handler/indexing/chunk_files_test.go
+++ b/application/handler/indexing/chunk_files_test.go
@@ -361,6 +361,56 @@ func TestRelativeFilePath(t *testing.T) {
 	}
 }
 
+func TestSafeDiskPath(t *testing.T) {
+	tests := []struct {
+		name      string
+		clonePath string
+		relPath   string
+		wantSafe  bool
+	}{
+		{
+			name:      "normal relative path",
+			clonePath: "/data/repos/myrepo",
+			relPath:   "src/main.go",
+			wantSafe:  true,
+		},
+		{
+			name:      "traversal escapes clone dir",
+			clonePath: "/data/repos/myrepo",
+			relPath:   "../../etc/passwd",
+			wantSafe:  false,
+		},
+		{
+			name:      "dot-dot in middle that stays inside",
+			clonePath: "/data/repos/myrepo",
+			relPath:   "src/../lib/util.go",
+			wantSafe:  true,
+		},
+		{
+			name:      "dot-dot that escapes via nested traversal",
+			clonePath: "/data/repos/myrepo",
+			relPath:   "src/../../../../etc/shadow",
+			wantSafe:  false,
+		},
+		{
+			name:      "single dot stays inside",
+			clonePath: "/data/repos/myrepo",
+			relPath:   ".",
+			wantSafe:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path, safe := safeDiskPath(tt.clonePath, tt.relPath)
+			assert.Equal(t, tt.wantSafe, safe)
+			if safe {
+				assert.NotEmpty(t, path)
+			}
+		})
+	}
+}
+
 func TestChunkFiles_HandlesAbsoluteFilePaths(t *testing.T) {
 	ctx := context.Background()
 	logger := zerolog.New(os.Stdout).Level(zerolog.ErrorLevel)

--- a/application/handler/indexing/create_page_image_embeddings.go
+++ b/application/handler/indexing/create_page_image_embeddings.go
@@ -166,7 +166,11 @@ func (h *CreatePageImageEmbeddings) Execute(ctx context.Context, payload map[str
 		}
 
 		relPath := relativeFilePath(f.Path(), clonedPath)
-		diskPath := filepath.Join(clonedPath, relPath)
+		diskPath, safe := safeDiskPath(clonedPath, relPath)
+		if !safe {
+			h.logger.Warn().Str("path", f.Path()).Msg("file path escapes clone directory, skipping")
+			continue
+		}
 
 		img, renderErr := rast.Render(diskPath, sl.Page())
 		if renderErr != nil {

--- a/application/handler/indexing/extract_page_images.go
+++ b/application/handler/indexing/extract_page_images.go
@@ -121,7 +121,12 @@ func (h *ExtractPageImages) Execute(ctx context.Context, payload map[string]any)
 		tracker.SetCurrent(ctx, processed, fmt.Sprintf("Extracting pages from %s", f.Path()))
 
 		relPath := relativeFilePath(f.Path(), clonedPath)
-		diskPath := filepath.Join(clonedPath, relPath)
+		diskPath, safe := safeDiskPath(clonedPath, relPath)
+		if !safe {
+			h.logger.Warn().Str("path", f.Path()).Msg("file path escapes clone directory, skipping")
+			processed++
+			continue
+		}
 
 		rast, _ := h.rasterizers.For(ext)
 		pageCount, countErr := rast.PageCount(diskPath)

--- a/infrastructure/rasterization/image.go
+++ b/infrastructure/rasterization/image.go
@@ -5,15 +5,21 @@ import (
 	"image"
 	// Decoders registered in office.go cover gif, jpeg, png, bmp, tiff, webp.
 	"os"
+	"path/filepath"
+	"strings"
 )
 
 // StandaloneImage is a Rasterizer for plain image files.
-// Each file is treated as a single "page".
-type StandaloneImage struct{}
+// Each file is treated as a single "page". Paths are validated
+// against a base directory to prevent path traversal.
+type StandaloneImage struct {
+	baseDir string
+}
 
 // NewStandaloneImage creates a StandaloneImage rasterizer.
-func NewStandaloneImage() *StandaloneImage {
-	return &StandaloneImage{}
+// All rendered paths must resolve within baseDir.
+func NewStandaloneImage(baseDir string) *StandaloneImage {
+	return &StandaloneImage{baseDir: filepath.Clean(baseDir)}
 }
 
 // PageCount always returns 1 — a standalone image is a single page.
@@ -27,15 +33,20 @@ func (s *StandaloneImage) Render(path string, page int) (image.Image, error) {
 		return nil, fmt.Errorf("page %d out of range [1, 1]", page)
 	}
 
-	f, err := os.Open(path)
+	clean := filepath.Clean(path)
+	if !strings.HasPrefix(clean, s.baseDir+string(filepath.Separator)) && clean != s.baseDir {
+		return nil, fmt.Errorf("path %s is outside base directory", path)
+	}
+
+	f, err := os.Open(clean)
 	if err != nil {
-		return nil, fmt.Errorf("open %s: %w", path, err)
+		return nil, fmt.Errorf("open %s: %w", clean, err)
 	}
 	defer func() { _ = f.Close() }()
 
 	img, _, err := image.Decode(f)
 	if err != nil {
-		return nil, fmt.Errorf("decode %s: %w", path, err)
+		return nil, fmt.Errorf("decode %s: %w", clean, err)
 	}
 	return img, nil
 }

--- a/infrastructure/rasterization/image.go
+++ b/infrastructure/rasterization/image.go
@@ -1,0 +1,44 @@
+package rasterization
+
+import (
+	"fmt"
+	"image"
+	// Decoders registered in office.go cover gif, jpeg, png, bmp, tiff, webp.
+	"os"
+)
+
+// StandaloneImage is a Rasterizer for plain image files.
+// Each file is treated as a single "page".
+type StandaloneImage struct{}
+
+// NewStandaloneImage creates a StandaloneImage rasterizer.
+func NewStandaloneImage() *StandaloneImage {
+	return &StandaloneImage{}
+}
+
+// PageCount always returns 1 — a standalone image is a single page.
+func (s *StandaloneImage) PageCount(_ string) (int, error) {
+	return 1, nil
+}
+
+// Render decodes the image file and returns it.
+func (s *StandaloneImage) Render(path string, page int) (image.Image, error) {
+	if page != 1 {
+		return nil, fmt.Errorf("page %d out of range [1, 1]", page)
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open %s: %w", path, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	img, _, err := image.Decode(f)
+	if err != nil {
+		return nil, fmt.Errorf("decode %s: %w", path, err)
+	}
+	return img, nil
+}
+
+// Close is a no-op.
+func (s *StandaloneImage) Close() error { return nil }

--- a/infrastructure/rasterization/image.go
+++ b/infrastructure/rasterization/image.go
@@ -5,21 +5,15 @@ import (
 	"image"
 	// Decoders registered in office.go cover gif, jpeg, png, bmp, tiff, webp.
 	"os"
-	"path/filepath"
-	"strings" // used for traversal check in Render
 )
 
 // StandaloneImage is a Rasterizer for plain image files.
-// Each file is treated as a single "page". Paths are validated
-// against a base directory to prevent path traversal.
-type StandaloneImage struct {
-	baseDir string
-}
+// Each file is treated as a single "page".
+type StandaloneImage struct{}
 
 // NewStandaloneImage creates a StandaloneImage rasterizer.
-// All rendered paths must resolve within baseDir.
-func NewStandaloneImage(baseDir string) *StandaloneImage {
-	return &StandaloneImage{baseDir: filepath.Clean(baseDir)}
+func NewStandaloneImage() *StandaloneImage {
+	return &StandaloneImage{}
 }
 
 // PageCount always returns 1 — a standalone image is a single page.
@@ -28,30 +22,20 @@ func (s *StandaloneImage) PageCount(_ string) (int, error) {
 }
 
 // Render decodes the image file and returns it.
-// The path is validated against the base directory to prevent traversal.
 func (s *StandaloneImage) Render(path string, page int) (image.Image, error) {
 	if page != 1 {
 		return nil, fmt.Errorf("page %d out of range [1, 1]", page)
 	}
 
-	// Compute a relative path from the base directory and reject traversal.
-	rel, err := filepath.Rel(s.baseDir, path)
-	if err != nil || strings.HasPrefix(rel, "..") {
-		return nil, fmt.Errorf("path %s is outside base directory", path)
-	}
-
-	// Re-join to produce a clean, verified absolute path.
-	safe := filepath.Join(s.baseDir, rel)
-
-	f, err := os.Open(safe)
+	f, err := os.Open(path)
 	if err != nil {
-		return nil, fmt.Errorf("open %s: %w", safe, err)
+		return nil, fmt.Errorf("open %s: %w", path, err)
 	}
 	defer func() { _ = f.Close() }()
 
 	img, _, err := image.Decode(f)
 	if err != nil {
-		return nil, fmt.Errorf("decode %s: %w", safe, err)
+		return nil, fmt.Errorf("decode %s: %w", path, err)
 	}
 	return img, nil
 }

--- a/infrastructure/rasterization/image.go
+++ b/infrastructure/rasterization/image.go
@@ -6,7 +6,7 @@ import (
 	// Decoders registered in office.go cover gif, jpeg, png, bmp, tiff, webp.
 	"os"
 	"path/filepath"
-	"strings"
+	"strings" // used for traversal check in Render
 )
 
 // StandaloneImage is a Rasterizer for plain image files.
@@ -28,25 +28,30 @@ func (s *StandaloneImage) PageCount(_ string) (int, error) {
 }
 
 // Render decodes the image file and returns it.
+// The path is validated against the base directory to prevent traversal.
 func (s *StandaloneImage) Render(path string, page int) (image.Image, error) {
 	if page != 1 {
 		return nil, fmt.Errorf("page %d out of range [1, 1]", page)
 	}
 
-	clean := filepath.Clean(path)
-	if !strings.HasPrefix(clean, s.baseDir+string(filepath.Separator)) && clean != s.baseDir {
+	// Compute a relative path from the base directory and reject traversal.
+	rel, err := filepath.Rel(s.baseDir, path)
+	if err != nil || strings.HasPrefix(rel, "..") {
 		return nil, fmt.Errorf("path %s is outside base directory", path)
 	}
 
-	f, err := os.Open(clean)
+	// Re-join to produce a clean, verified absolute path.
+	safe := filepath.Join(s.baseDir, rel)
+
+	f, err := os.Open(safe)
 	if err != nil {
-		return nil, fmt.Errorf("open %s: %w", clean, err)
+		return nil, fmt.Errorf("open %s: %w", safe, err)
 	}
 	defer func() { _ = f.Close() }()
 
 	img, _, err := image.Decode(f)
 	if err != nil {
-		return nil, fmt.Errorf("decode %s: %w", clean, err)
+		return nil, fmt.Errorf("decode %s: %w", safe, err)
 	}
 	return img, nil
 }

--- a/infrastructure/rasterization/image_test.go
+++ b/infrastructure/rasterization/image_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func writeTestImage(t *testing.T, name string, c color.Color) string {
+func writeTestImage(t *testing.T, dir, name string, c color.Color) string {
 	t.Helper()
 	img := image.NewRGBA(image.Rect(0, 0, 4, 4))
 	for y := range 4 {
@@ -23,22 +23,23 @@ func writeTestImage(t *testing.T, name string, c color.Color) string {
 	var buf bytes.Buffer
 	require.NoError(t, png.Encode(&buf, img))
 
-	path := filepath.Join(t.TempDir(), name)
+	path := filepath.Join(dir, name)
 	require.NoError(t, os.WriteFile(path, buf.Bytes(), 0o644))
 	return path
 }
 
 func TestStandaloneImage_PageCount(t *testing.T) {
-	rast := NewStandaloneImage()
+	rast := NewStandaloneImage("/any")
 	count, err := rast.PageCount("/any/path.png")
 	require.NoError(t, err)
 	require.Equal(t, 1, count)
 }
 
 func TestStandaloneImage_Render(t *testing.T) {
-	path := writeTestImage(t, "photo.png", color.RGBA{R: 255, A: 255})
+	dir := t.TempDir()
+	path := writeTestImage(t, dir, "photo.png", color.RGBA{R: 255, A: 255})
 
-	rast := NewStandaloneImage()
+	rast := NewStandaloneImage(dir)
 	img, err := rast.Render(path, 1)
 	require.NoError(t, err)
 	require.NotNil(t, img)
@@ -55,9 +56,10 @@ func TestStandaloneImage_Render(t *testing.T) {
 }
 
 func TestStandaloneImage_Render_OutOfRange(t *testing.T) {
-	path := writeTestImage(t, "photo.png", color.RGBA{R: 255, A: 255})
+	dir := t.TempDir()
+	path := writeTestImage(t, dir, "photo.png", color.RGBA{R: 255, A: 255})
 
-	rast := NewStandaloneImage()
+	rast := NewStandaloneImage(dir)
 
 	_, err := rast.Render(path, 0)
 	require.Error(t, err)
@@ -69,12 +71,22 @@ func TestStandaloneImage_Render_OutOfRange(t *testing.T) {
 }
 
 func TestStandaloneImage_Render_FileNotFound(t *testing.T) {
-	rast := NewStandaloneImage()
-	_, err := rast.Render("/nonexistent/file.png", 1)
+	dir := t.TempDir()
+	rast := NewStandaloneImage(dir)
+	_, err := rast.Render(filepath.Join(dir, "nonexistent.png"), 1)
 	require.Error(t, err)
 }
 
+func TestStandaloneImage_Render_PathTraversal(t *testing.T) {
+	dir := t.TempDir()
+	rast := NewStandaloneImage(dir)
+
+	_, err := rast.Render(filepath.Join(dir, "..", "etc", "passwd"), 1)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "outside base directory")
+}
+
 func TestStandaloneImage_Close(t *testing.T) {
-	rast := NewStandaloneImage()
+	rast := NewStandaloneImage("/any")
 	require.NoError(t, rast.Close())
 }

--- a/infrastructure/rasterization/image_test.go
+++ b/infrastructure/rasterization/image_test.go
@@ -1,0 +1,80 @@
+package rasterization
+
+import (
+	"bytes"
+	"image"
+	"image/color"
+	"image/png"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func writeTestImage(t *testing.T, name string, c color.Color) string {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, 4, 4))
+	for y := range 4 {
+		for x := range 4 {
+			img.Set(x, y, c)
+		}
+	}
+	var buf bytes.Buffer
+	require.NoError(t, png.Encode(&buf, img))
+
+	path := filepath.Join(t.TempDir(), name)
+	require.NoError(t, os.WriteFile(path, buf.Bytes(), 0o644))
+	return path
+}
+
+func TestStandaloneImage_PageCount(t *testing.T) {
+	rast := NewStandaloneImage()
+	count, err := rast.PageCount("/any/path.png")
+	require.NoError(t, err)
+	require.Equal(t, 1, count)
+}
+
+func TestStandaloneImage_Render(t *testing.T) {
+	path := writeTestImage(t, "photo.png", color.RGBA{R: 255, A: 255})
+
+	rast := NewStandaloneImage()
+	img, err := rast.Render(path, 1)
+	require.NoError(t, err)
+	require.NotNil(t, img)
+
+	bounds := img.Bounds()
+	require.Equal(t, 4, bounds.Dx())
+	require.Equal(t, 4, bounds.Dy())
+
+	r, g, b, a := img.At(0, 0).RGBA()
+	require.Equal(t, uint32(0xffff), r)
+	require.Equal(t, uint32(0), g)
+	require.Equal(t, uint32(0), b)
+	require.Equal(t, uint32(0xffff), a)
+}
+
+func TestStandaloneImage_Render_OutOfRange(t *testing.T) {
+	path := writeTestImage(t, "photo.png", color.RGBA{R: 255, A: 255})
+
+	rast := NewStandaloneImage()
+
+	_, err := rast.Render(path, 0)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "out of range")
+
+	_, err = rast.Render(path, 2)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "out of range")
+}
+
+func TestStandaloneImage_Render_FileNotFound(t *testing.T) {
+	rast := NewStandaloneImage()
+	_, err := rast.Render("/nonexistent/file.png", 1)
+	require.Error(t, err)
+}
+
+func TestStandaloneImage_Close(t *testing.T) {
+	rast := NewStandaloneImage()
+	require.NoError(t, rast.Close())
+}

--- a/infrastructure/rasterization/image_test.go
+++ b/infrastructure/rasterization/image_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func writeTestImage(t *testing.T, dir, name string, c color.Color) string {
+func writeTestImage(t *testing.T, name string, c color.Color) string {
 	t.Helper()
 	img := image.NewRGBA(image.Rect(0, 0, 4, 4))
 	for y := range 4 {
@@ -23,23 +23,22 @@ func writeTestImage(t *testing.T, dir, name string, c color.Color) string {
 	var buf bytes.Buffer
 	require.NoError(t, png.Encode(&buf, img))
 
-	path := filepath.Join(dir, name)
+	path := filepath.Join(t.TempDir(), name)
 	require.NoError(t, os.WriteFile(path, buf.Bytes(), 0o644))
 	return path
 }
 
 func TestStandaloneImage_PageCount(t *testing.T) {
-	rast := NewStandaloneImage("/any")
+	rast := NewStandaloneImage()
 	count, err := rast.PageCount("/any/path.png")
 	require.NoError(t, err)
 	require.Equal(t, 1, count)
 }
 
 func TestStandaloneImage_Render(t *testing.T) {
-	dir := t.TempDir()
-	path := writeTestImage(t, dir, "photo.png", color.RGBA{R: 255, A: 255})
+	path := writeTestImage(t, "photo.png", color.RGBA{R: 255, A: 255})
 
-	rast := NewStandaloneImage(dir)
+	rast := NewStandaloneImage()
 	img, err := rast.Render(path, 1)
 	require.NoError(t, err)
 	require.NotNil(t, img)
@@ -56,10 +55,9 @@ func TestStandaloneImage_Render(t *testing.T) {
 }
 
 func TestStandaloneImage_Render_OutOfRange(t *testing.T) {
-	dir := t.TempDir()
-	path := writeTestImage(t, dir, "photo.png", color.RGBA{R: 255, A: 255})
+	path := writeTestImage(t, "photo.png", color.RGBA{R: 255, A: 255})
 
-	rast := NewStandaloneImage(dir)
+	rast := NewStandaloneImage()
 
 	_, err := rast.Render(path, 0)
 	require.Error(t, err)
@@ -71,22 +69,12 @@ func TestStandaloneImage_Render_OutOfRange(t *testing.T) {
 }
 
 func TestStandaloneImage_Render_FileNotFound(t *testing.T) {
-	dir := t.TempDir()
-	rast := NewStandaloneImage(dir)
-	_, err := rast.Render(filepath.Join(dir, "nonexistent.png"), 1)
+	rast := NewStandaloneImage()
+	_, err := rast.Render("/nonexistent/file.png", 1)
 	require.Error(t, err)
-}
-
-func TestStandaloneImage_Render_PathTraversal(t *testing.T) {
-	dir := t.TempDir()
-	rast := NewStandaloneImage(dir)
-
-	_, err := rast.Render(filepath.Join(dir, "..", "etc", "passwd"), 1)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "outside base directory")
 }
 
 func TestStandaloneImage_Close(t *testing.T) {
-	rast := NewStandaloneImage("/any")
+	rast := NewStandaloneImage()
 	require.NoError(t, rast.Close())
 }

--- a/kodit.go
+++ b/kodit.go
@@ -439,7 +439,7 @@ func New(opts ...Option) (*Client, error) {
 		rasterizers.Register(ext, officeRast)
 	}
 
-	imageRast := rasterization.NewStandaloneImage()
+	imageRast := rasterization.NewStandaloneImage(cloneDir)
 	for _, ext := range []string{".png", ".jpg", ".jpeg", ".gif", ".bmp", ".tiff", ".tif", ".webp"} {
 		rasterizers.Register(ext, imageRast)
 	}

--- a/kodit.go
+++ b/kodit.go
@@ -439,7 +439,7 @@ func New(opts ...Option) (*Client, error) {
 		rasterizers.Register(ext, officeRast)
 	}
 
-	imageRast := rasterization.NewStandaloneImage(cloneDir)
+	imageRast := rasterization.NewStandaloneImage()
 	for _, ext := range []string{".png", ".jpg", ".jpeg", ".gif", ".bmp", ".tiff", ".tif", ".webp"} {
 		rasterizers.Register(ext, imageRast)
 	}

--- a/kodit.go
+++ b/kodit.go
@@ -439,6 +439,11 @@ func New(opts ...Option) (*Client, error) {
 		rasterizers.Register(ext, officeRast)
 	}
 
+	imageRast := rasterization.NewStandaloneImage()
+	for _, ext := range []string{".png", ".jpg", ".jpeg", ".gif", ".bmp", ".tiff", ".tif", ".webp"} {
+		rasterizers.Register(ext, imageRast)
+	}
+
 	// Create enrichment infrastructure (always available)
 	archDiscoverer := enricher.NewPhysicalArchitectureService()
 	schemaDiscoverer := enricher.NewDatabaseSchemaService()


### PR DESCRIPTION
## Summary

- Add support for indexing standalone image files (PNG, JPG, JPEG, GIF, BMP, TIFF, WebP) through the existing vision embedding pipeline. Each image is treated as a single page and encoded to JPEG at quality 80.
- Add path traversal containment check (safeDiskPath) to all three indexing handlers (ChunkFiles, ExtractPageImages, CreatePageImageEmbeddings) to prevent crafted ../-style filenames from escaping the clone directory.

## Test plan

- [x] StandaloneImage rasterizer unit tests (PageCount, Render, out-of-range, file-not-found, Close)
- [x] safeDiskPath unit tests (normal paths, traversal escapes, nested traversal, edge cases)
- [x] make check passes

Assisted by AI. Co-Authored-By: Helix <noreply@helix.ml>