### PR TITLE
refactor: simplify embedding store by deriving dimension from SaveAll

### DIFF
--- a/infrastructure/persistence/embedding_store_vectorchord.go
+++ b/infrastructure/persistence/embedding_store_vectorchord.go
@@ -39,30 +39,66 @@ WHERE c.relname = '%s_idx'`
 var ErrVectorInitializationFailed = errors.New("failed to initialize VectorChord vector repository")
 
 // VectorChordEmbeddingStore implements search.EmbeddingStore using VectorChord PostgreSQL extension.
+// Table creation and dimension validation are deferred to the first method call
+// so that construction is side-effect-free and does not race with other clients
+// starting concurrently.
 type VectorChordEmbeddingStore struct {
 	database.Repository[search.Embedding, PgEmbeddingModel]
 	logger  zerolog.Logger
 	indexMu sync.Mutex
+
+	// Lazy initialization fields.
+	embedder    search.Embedder
+	onRebuilt   func(context.Context)
+	initMu      sync.Mutex
+	initialized bool
 }
 
-// NewVectorChordEmbeddingStore creates a new VectorChordEmbeddingStore, eagerly
-// initializing the extension, table, index, and verifying the dimension.
-// The returned bool is true when the table was dropped and recreated due to a
-// dimension mismatch (e.g. the user switched embedding providers).
-func NewVectorChordEmbeddingStore(ctx context.Context, db database.Database, taskName TaskName, dimension int, logger zerolog.Logger) (*VectorChordEmbeddingStore, bool, error) {
+// NewVectorChordEmbeddingStore creates a new VectorChordEmbeddingStore.
+// The extension, table, and dimension validation are deferred to the first
+// method call (SaveAll, Search, Find, etc.).
+//
+// embedder is used once to probe the vector dimension.
+// onRebuilt is called (at most once) if the table had to be dropped and
+// recreated due to a dimension mismatch; pass nil if no action is needed.
+func NewVectorChordEmbeddingStore(db database.Database, taskName TaskName, embedder search.Embedder, onRebuilt func(context.Context), logger zerolog.Logger) *VectorChordEmbeddingStore {
 	tableName := fmt.Sprintf("vectorchord_%s_embeddings", taskName)
-	s := &VectorChordEmbeddingStore{
+	return &VectorChordEmbeddingStore{
 		Repository: database.NewRepositoryForTable[search.Embedding, PgEmbeddingModel](
 			db, pgEmbeddingMapper{}, "embedding", tableName,
 		),
-		logger: logger,
+		embedder:  embedder,
+		onRebuilt: onRebuilt,
+		logger:    logger,
+	}
+}
+
+// ensureInitialized performs extension creation, table DDL, and dimension
+// validation on the first call. Subsequent calls are no-ops. If the first
+// attempt fails the store remains uninitialized so the next call retries.
+func (s *VectorChordEmbeddingStore) ensureInitialized(ctx context.Context) error {
+	s.initMu.Lock()
+	defer s.initMu.Unlock()
+	if s.initialized {
+		return nil
 	}
 
-	rawDB := db.Session(ctx)
+	// Probe embedding dimension.
+	probe, err := s.embedder.Embed(ctx, []search.EmbeddingItem{search.NewTextItem("dimension probe")})
+	if err != nil {
+		return fmt.Errorf("probe embedding dimension: %w", err)
+	}
+	if len(probe) == 0 || len(probe[0]) == 0 {
+		return fmt.Errorf("failed to obtain embedding dimension from provider")
+	}
+	dimension := len(probe[0])
 
-	// Create extension
+	tableName := s.Table()
+	rawDB := s.DB(ctx)
+
+	// Create extension.
 	if err := rawDB.Exec(vcCreateVChordExtension).Error; err != nil {
-		return nil, false, errors.Join(ErrVectorInitializationFailed, fmt.Errorf("create extension: %w", err))
+		return errors.Join(ErrVectorInitializationFailed, fmt.Errorf("create extension: %w", err))
 	}
 
 	createTableSQL := fmt.Sprintf(`
@@ -72,9 +108,9 @@ CREATE TABLE IF NOT EXISTS %s (
     embedding VECTOR(%d) NOT NULL
 )`, tableName, dimension)
 
-	// Create table (dynamic dimension requires raw SQL)
+	// Create table (dynamic dimension requires raw SQL).
 	if err := rawDB.Exec(createTableSQL).Error; err != nil {
-		return nil, false, errors.Join(ErrVectorInitializationFailed, fmt.Errorf("create table: %w", err))
+		return errors.Join(ErrVectorInitializationFailed, fmt.Errorf("create table: %w", err))
 	}
 
 	// Check whether the existing table dimension matches the provider.
@@ -82,24 +118,58 @@ CREATE TABLE IF NOT EXISTS %s (
 	checkDimensionSQL := fmt.Sprintf(vcCheckDimensionTemplate, tableName)
 	result := rawDB.Raw(checkDimensionSQL).Scan(&dbDimension)
 	if result.Error != nil && !errors.Is(result.Error, gorm.ErrRecordNotFound) {
-		return nil, false, errors.Join(ErrVectorInitializationFailed, fmt.Errorf("check dimension: %w", result.Error))
+		return errors.Join(ErrVectorInitializationFailed, fmt.Errorf("check dimension: %w", result.Error))
 	}
 
-	rebuilt := false
 	if result.RowsAffected > 0 && dbDimension != dimension {
-		logger.Warn().Str("table", tableName).Int("old_dimension", dbDimension).Int("new_dimension", dimension).Msg("embedding dimension changed, dropping old table for re-indexing")
+		s.logger.Warn().Str("table", tableName).Int("old_dimension", dbDimension).Int("new_dimension", dimension).Msg("embedding dimension changed, dropping old table for re-indexing")
 
 		dropSQL := fmt.Sprintf("DROP TABLE %s CASCADE", tableName)
 		if err := rawDB.Exec(dropSQL).Error; err != nil {
-			return nil, false, errors.Join(ErrVectorInitializationFailed, fmt.Errorf("drop table: %w", err))
+			return errors.Join(ErrVectorInitializationFailed, fmt.Errorf("drop table: %w", err))
 		}
 		if err := rawDB.Exec(createTableSQL).Error; err != nil {
-			return nil, false, errors.Join(ErrVectorInitializationFailed, fmt.Errorf("recreate table: %w", err))
+			return errors.Join(ErrVectorInitializationFailed, fmt.Errorf("recreate table: %w", err))
 		}
-		rebuilt = true
+		if s.onRebuilt != nil {
+			s.onRebuilt(ctx)
+		}
 	}
 
-	return s, rebuilt, nil
+	s.initialized = true
+	return nil
+}
+
+// Find retrieves embeddings matching the given options.
+func (s *VectorChordEmbeddingStore) Find(ctx context.Context, options ...repository.Option) ([]search.Embedding, error) {
+	if err := s.ensureInitialized(ctx); err != nil {
+		return nil, err
+	}
+	return s.Repository.Find(ctx, options...)
+}
+
+// Exists checks whether any row matches the given options.
+func (s *VectorChordEmbeddingStore) Exists(ctx context.Context, options ...repository.Option) (bool, error) {
+	if err := s.ensureInitialized(ctx); err != nil {
+		return false, err
+	}
+	return s.Repository.Exists(ctx, options...)
+}
+
+// DeleteBy removes documents matching the given options.
+func (s *VectorChordEmbeddingStore) DeleteBy(ctx context.Context, options ...repository.Option) error {
+	if err := s.ensureInitialized(ctx); err != nil {
+		return err
+	}
+	return s.Repository.DeleteBy(ctx, options...)
+}
+
+// Count returns the number of rows matching the given options.
+func (s *VectorChordEmbeddingStore) Count(ctx context.Context, options ...repository.Option) (int64, error) {
+	if err := s.ensureInitialized(ctx); err != nil {
+		return 0, err
+	}
+	return s.Repository.Count(ctx, options...)
 }
 
 // SaveAll persists pre-computed embeddings using batched upsert, then ensures
@@ -107,6 +177,9 @@ CREATE TABLE IF NOT EXISTS %s (
 func (s *VectorChordEmbeddingStore) SaveAll(ctx context.Context, embeddings []search.Embedding) error {
 	if len(embeddings) == 0 {
 		return nil
+	}
+	if err := s.ensureInitialized(ctx); err != nil {
+		return err
 	}
 
 	models := make([]PgEmbeddingModel, len(embeddings))
@@ -194,6 +267,9 @@ func probeCount(rows int64) int {
 // Search performs vector similarity search within a transaction so that
 // the vchordrq.probes session variable is visible to the query.
 func (s *VectorChordEmbeddingStore) Search(ctx context.Context, options ...repository.Option) ([]search.Result, error) {
+	if err := s.ensureInitialized(ctx); err != nil {
+		return nil, err
+	}
 	var count int64
 	db := s.DB(ctx)
 	if err := db.Table(s.Table()).Count(&count).Error; err != nil {

--- a/infrastructure/persistence/embedding_store_vectorchord.go
+++ b/infrastructure/persistence/embedding_store_vectorchord.go
@@ -39,59 +39,48 @@ WHERE c.relname = '%s_idx'`
 var ErrVectorInitializationFailed = errors.New("failed to initialize VectorChord vector repository")
 
 // VectorChordEmbeddingStore implements search.EmbeddingStore using VectorChord PostgreSQL extension.
-// Table creation and dimension validation are deferred to the first method call
-// so that construction is side-effect-free and does not race with other clients
-// starting concurrently.
+// Table creation is deferred to the first SaveAll call, using the actual
+// embedding dimension. Read methods work against whatever table state exists;
+// if no data has been written yet they return empty results.
 type VectorChordEmbeddingStore struct {
 	database.Repository[search.Embedding, PgEmbeddingModel]
 	logger  zerolog.Logger
 	indexMu sync.Mutex
 
-	// Lazy initialization fields.
-	embedder    search.Embedder
-	onRebuilt   func(context.Context)
-	initMu      sync.Mutex
-	initialized bool
+	onRebuilt  func(context.Context)
+	tableMu    sync.Mutex
+	tableReady bool
 }
 
 // NewVectorChordEmbeddingStore creates a new VectorChordEmbeddingStore.
-// The extension, table, and dimension validation are deferred to the first
-// method call (SaveAll, Search, Find, etc.).
+// Construction is side-effect-free; the VectorChord extension and table are
+// created lazily on the first SaveAll call using the actual embedding dimension.
 //
-// embedder is used once to probe the vector dimension.
-// onRebuilt is called (at most once) if the table had to be dropped and
-// recreated due to a dimension mismatch; pass nil if no action is needed.
-func NewVectorChordEmbeddingStore(db database.Database, taskName TaskName, embedder search.Embedder, onRebuilt func(context.Context), logger zerolog.Logger) *VectorChordEmbeddingStore {
+// onRebuilt is called (at most once) if an existing table had to be dropped
+// and recreated due to a dimension mismatch; pass nil if no action is needed.
+func NewVectorChordEmbeddingStore(db database.Database, taskName TaskName, onRebuilt func(context.Context), logger zerolog.Logger) *VectorChordEmbeddingStore {
 	tableName := fmt.Sprintf("vectorchord_%s_embeddings", taskName)
 	return &VectorChordEmbeddingStore{
 		Repository: database.NewRepositoryForTable[search.Embedding, PgEmbeddingModel](
 			db, pgEmbeddingMapper{}, "embedding", tableName,
 		),
-		embedder:  embedder,
 		onRebuilt: onRebuilt,
 		logger:    logger,
 	}
 }
 
-// ensureInitialized performs extension creation, table DDL, and dimension
-// validation on the first call. Subsequent calls are no-ops. If the first
-// attempt fails the store remains uninitialized so the next call retries.
-func (s *VectorChordEmbeddingStore) ensureInitialized(ctx context.Context) error {
-	s.initMu.Lock()
-	defer s.initMu.Unlock()
-	if s.initialized {
+// ensureTable creates the VectorChord extension and embedding table if they
+// do not already exist. If the table exists with a different vector dimension
+// it is dropped and recreated, and the onRebuilt callback fires.
+//
+// Called from SaveAll only — dimension is derived from the embeddings
+// themselves, so no probe call is needed.
+func (s *VectorChordEmbeddingStore) ensureTable(ctx context.Context, dimension int) error {
+	s.tableMu.Lock()
+	defer s.tableMu.Unlock()
+	if s.tableReady {
 		return nil
 	}
-
-	// Probe embedding dimension.
-	probe, err := s.embedder.Embed(ctx, []search.EmbeddingItem{search.NewTextItem("dimension probe")})
-	if err != nil {
-		return fmt.Errorf("probe embedding dimension: %w", err)
-	}
-	if len(probe) == 0 || len(probe[0]) == 0 {
-		return fmt.Errorf("failed to obtain embedding dimension from provider")
-	}
-	dimension := len(probe[0])
 
 	tableName := s.Table()
 	rawDB := s.DB(ctx)
@@ -113,7 +102,7 @@ CREATE TABLE IF NOT EXISTS %s (
 		return errors.Join(ErrVectorInitializationFailed, fmt.Errorf("create table: %w", err))
 	}
 
-	// Check whether the existing table dimension matches the provider.
+	// Check whether the existing table dimension matches the embeddings.
 	var dbDimension int
 	checkDimensionSQL := fmt.Sprintf(vcCheckDimensionTemplate, tableName)
 	result := rawDB.Raw(checkDimensionSQL).Scan(&dbDimension)
@@ -136,40 +125,8 @@ CREATE TABLE IF NOT EXISTS %s (
 		}
 	}
 
-	s.initialized = true
+	s.tableReady = true
 	return nil
-}
-
-// Find retrieves embeddings matching the given options.
-func (s *VectorChordEmbeddingStore) Find(ctx context.Context, options ...repository.Option) ([]search.Embedding, error) {
-	if err := s.ensureInitialized(ctx); err != nil {
-		return nil, err
-	}
-	return s.Repository.Find(ctx, options...)
-}
-
-// Exists checks whether any row matches the given options.
-func (s *VectorChordEmbeddingStore) Exists(ctx context.Context, options ...repository.Option) (bool, error) {
-	if err := s.ensureInitialized(ctx); err != nil {
-		return false, err
-	}
-	return s.Repository.Exists(ctx, options...)
-}
-
-// DeleteBy removes documents matching the given options.
-func (s *VectorChordEmbeddingStore) DeleteBy(ctx context.Context, options ...repository.Option) error {
-	if err := s.ensureInitialized(ctx); err != nil {
-		return err
-	}
-	return s.Repository.DeleteBy(ctx, options...)
-}
-
-// Count returns the number of rows matching the given options.
-func (s *VectorChordEmbeddingStore) Count(ctx context.Context, options ...repository.Option) (int64, error) {
-	if err := s.ensureInitialized(ctx); err != nil {
-		return 0, err
-	}
-	return s.Repository.Count(ctx, options...)
 }
 
 // SaveAll persists pre-computed embeddings using batched upsert, then ensures
@@ -178,7 +135,7 @@ func (s *VectorChordEmbeddingStore) SaveAll(ctx context.Context, embeddings []se
 	if len(embeddings) == 0 {
 		return nil
 	}
-	if err := s.ensureInitialized(ctx); err != nil {
+	if err := s.ensureTable(ctx, len(embeddings[0].Vector())); err != nil {
 		return err
 	}
 
@@ -267,9 +224,6 @@ func probeCount(rows int64) int {
 // Search performs vector similarity search within a transaction so that
 // the vchordrq.probes session variable is visible to the query.
 func (s *VectorChordEmbeddingStore) Search(ctx context.Context, options ...repository.Option) ([]search.Result, error) {
-	if err := s.ensureInitialized(ctx); err != nil {
-		return nil, err
-	}
 	var count int64
 	db := s.DB(ctx)
 	if err := db.Table(s.Table()).Count(&count).Error; err != nil {

--- a/kodit.go
+++ b/kodit.go
@@ -281,27 +281,32 @@ func New(opts ...Option) (*Client, error) {
 		Files:        fileStore,
 	}
 
-	// Probe embedding dimension once (only needed for PostgreSQL vector stores
-	// that require VECTOR(N) column declarations; SQLite stores JSON and needs
-	// no dimension up front).
-	var dimension int
-	needsDimensionProbe := cfg.embeddingProvider != nil &&
-		cfg.database == databasePostgresVectorchord
-	if needsDimensionProbe {
-		probe, err := cfg.embeddingProvider.Embed(ctx, []search.EmbeddingItem{search.NewTextItem("dimension probe")})
-		if err != nil {
-			errClose := db.Close()
-			return nil, errors.Join(fmt.Errorf("probe embedding dimension: %w", err), errClose)
+	// The onRebuilt callback fires lazily (on first store use) if an
+	// embedding table had to be dropped and recreated due to a dimension
+	// change. It captures queue and repoStore by reference; both are
+	// assigned before New() returns and therefore before any store method
+	// can be called.
+	var queue *service.Queue
+	onRebuilt := func(ctx context.Context) {
+		repos, repoErr := repoStore.Find(ctx)
+		if repoErr != nil {
+			logger.Error().Err(repoErr).Msg("failed to find repositories for re-index after dimension change")
+			return
 		}
-		if len(probe) == 0 || len(probe[0]) == 0 {
-			errClose := db.Close()
-			return nil, errors.Join(fmt.Errorf("failed to obtain embedding dimension from provider"), errClose)
+		operations := []task.Operation{task.OperationCloneRepository, task.OperationSyncRepository}
+		for _, repo := range repos {
+			payload := map[string]any{"repository_id": repo.ID()}
+			if enqErr := queue.EnqueueOperations(ctx, operations, task.PriorityNormal, payload); enqErr != nil {
+				logger.Error().Err(enqErr).Int64("repository_id", repo.ID()).Msg("failed to enqueue re-index after dimension change")
+				return
+			}
 		}
-		dimension = len(probe[0])
+		logger.Info().Int("repositories", len(repos)).Msg("embedding dimension changed, enqueued sync for re-indexing")
 	}
 
-	// Create search stores based on storage type
-	textEmbeddingStore, codeEmbeddingStore, bm25Store, embeddingsRebuilt, err := buildSearchStores(ctx, cfg, db, dimension, logger)
+	// Create search stores based on storage type. VectorChord stores
+	// defer their dimension probe and DDL to the first method call.
+	textEmbeddingStore, codeEmbeddingStore, bm25Store, err := buildSearchStores(cfg, db, onRebuilt, logger)
 	if err != nil {
 		errClose := db.Close()
 		return nil, errors.Join(fmt.Errorf("search stores: %w", err), errClose)
@@ -331,19 +336,6 @@ func New(opts ...Option) (*Client, error) {
 		}
 	}
 
-	// Probe vision embedding dimension for PostgreSQL when using a remote provider.
-	visionDimension := 768 // SigLIP2 default
-	if cfg.visionEmbedder != nil && cfg.database == databasePostgresVectorchord {
-		probe, vErr := cfg.visionEmbedder.Embed(ctx, []search.EmbeddingItem{search.NewTextItem("dimension probe")})
-		if vErr != nil {
-			errClose := db.Close()
-			return nil, errors.Join(fmt.Errorf("probe vision embedding dimension: %w", vErr), errClose)
-		}
-		if len(probe) > 0 && len(probe[0]) > 0 {
-			visionDimension = len(probe[0])
-		}
-	}
-
 	// Create vision embedding store and index.
 	var visionEmbeddingStore search.EmbeddingStore
 	switch cfg.database {
@@ -354,11 +346,7 @@ func New(opts ...Option) (*Client, error) {
 		}
 		visionEmbeddingStore = vs
 	case databasePostgresVectorchord:
-		vs, _, vsErr := persistence.NewVectorChordEmbeddingStore(ctx, db, persistence.TaskNameVision, visionDimension, logger)
-		if vsErr != nil {
-			return nil, fmt.Errorf("vision embedding store: %w", vsErr)
-		}
-		visionEmbeddingStore = vs
+		visionEmbeddingStore = persistence.NewVectorChordEmbeddingStore(db, persistence.TaskNameVision, visionEmbedder, nil, logger)
 	}
 	visionIndex := handler.VectorIndex{
 		Store: visionEmbeddingStore,
@@ -366,7 +354,7 @@ func New(opts ...Option) (*Client, error) {
 
 	// Create application services
 	registry := service.NewRegistry()
-	queue := service.NewQueue(taskStore, logger)
+	queue = service.NewQueue(taskStore, logger)
 
 	enrichQSvc := service.NewEnrichment(enrichmentStore, associationStore, bm25Store, codeEmbeddingStore, textEmbeddingStore, visionEmbeddingStore, lineRangeStore)
 	trackingSvc := service.NewTracking(statusStore, taskStore)
@@ -563,25 +551,6 @@ func New(opts ...Option) (*Client, error) {
 	}
 	periodicSync.Start(ctx)
 
-	// If embedding tables were rebuilt (dimension change), enqueue a sync for
-	// every repository so enrichments get re-embedded with the new model.
-	if embeddingsRebuilt {
-		repos, repoErr := repoStore.Find(ctx)
-		if repoErr != nil {
-			_ = db.Close()
-			return nil, fmt.Errorf("find repositories for re-index: %w", repoErr)
-		}
-		operations := []task.Operation{task.OperationCloneRepository, task.OperationSyncRepository}
-		for _, repo := range repos {
-			payload := map[string]any{"repository_id": repo.ID()}
-			if enqErr := queue.EnqueueOperations(ctx, operations, task.PriorityNormal, payload); enqErr != nil {
-				_ = db.Close()
-				return nil, fmt.Errorf("enqueue re-index for repository %d: %w", repo.ID(), enqErr)
-			}
-		}
-		logger.Info().Int("repositories", len(repos)).Msg("embedding dimension changed, enqueued sync for re-indexing")
-	}
-
 	return client, nil
 }
 
@@ -642,43 +611,35 @@ func (c *Client) Rasterizers() *rasterization.Registry {
 }
 
 // buildSearchStores creates the search stores based on config.
-// The returned rebuilt bool is true when any VectorChord embedding table was
-// dropped and recreated due to a dimension change (requiring a full re-index).
-func buildSearchStores(ctx context.Context, cfg *clientConfig, db database.Database, dimension int, logger zerolog.Logger) (textEmbeddingStore, codeEmbeddingStore search.EmbeddingStore, bm25Store search.BM25Store, rebuilt bool, err error) {
+// VectorChord embedding stores are constructed without touching the database;
+// their dimension probe and DDL run lazily on first use.
+func buildSearchStores(cfg *clientConfig, db database.Database, onRebuilt func(context.Context), logger zerolog.Logger) (textEmbeddingStore, codeEmbeddingStore search.EmbeddingStore, bm25Store search.BM25Store, err error) {
 	switch cfg.database {
 	case databaseSQLite:
 		bm25Store, err = persistence.NewSQLiteBM25Store(db, logger)
 		if err != nil {
-			return nil, nil, nil, false, fmt.Errorf("bm25 store: %w", err)
+			return nil, nil, nil, fmt.Errorf("bm25 store: %w", err)
 		}
 		if cfg.embeddingProvider != nil {
 			textStore, textErr := persistence.NewSQLiteEmbeddingStore(db, persistence.TaskNameText, logger)
 			if textErr != nil {
-				return nil, nil, nil, false, fmt.Errorf("text embedding store: %w", textErr)
+				return nil, nil, nil, fmt.Errorf("text embedding store: %w", textErr)
 			}
 			textEmbeddingStore = textStore
 			codeStore, codeErr := persistence.NewSQLiteEmbeddingStore(db, persistence.TaskNameCode, logger)
 			if codeErr != nil {
-				return nil, nil, nil, false, fmt.Errorf("code embedding store: %w", codeErr)
+				return nil, nil, nil, fmt.Errorf("code embedding store: %w", codeErr)
 			}
 			codeEmbeddingStore = codeStore
 		}
 	case databasePostgresVectorchord:
 		bm25Store, err = persistence.NewVectorChordBM25Store(db, logger)
 		if err != nil {
-			return nil, nil, nil, false, fmt.Errorf("bm25 store: %w", err)
+			return nil, nil, nil, fmt.Errorf("bm25 store: %w", err)
 		}
 		if cfg.embeddingProvider != nil {
-			var textRebuilt, codeRebuilt bool
-			textEmbeddingStore, textRebuilt, err = persistence.NewVectorChordEmbeddingStore(ctx, db, persistence.TaskNameText, dimension, logger)
-			if err != nil {
-				return nil, nil, nil, false, fmt.Errorf("text embedding store: %w", err)
-			}
-			codeEmbeddingStore, codeRebuilt, err = persistence.NewVectorChordEmbeddingStore(ctx, db, persistence.TaskNameCode, dimension, logger)
-			if err != nil {
-				return nil, nil, nil, false, fmt.Errorf("code embedding store: %w", err)
-			}
-			rebuilt = textRebuilt || codeRebuilt
+			textEmbeddingStore = persistence.NewVectorChordEmbeddingStore(db, persistence.TaskNameText, cfg.embeddingProvider, onRebuilt, logger)
+			codeEmbeddingStore = persistence.NewVectorChordEmbeddingStore(db, persistence.TaskNameCode, cfg.embeddingProvider, onRebuilt, logger)
 		}
 	}
 	return

--- a/kodit.go
+++ b/kodit.go
@@ -346,7 +346,7 @@ func New(opts ...Option) (*Client, error) {
 		}
 		visionEmbeddingStore = vs
 	case databasePostgresVectorchord:
-		visionEmbeddingStore = persistence.NewVectorChordEmbeddingStore(db, persistence.TaskNameVision, visionEmbedder, nil, logger)
+		visionEmbeddingStore = persistence.NewVectorChordEmbeddingStore(db, persistence.TaskNameVision, nil, logger)
 	}
 	visionIndex := handler.VectorIndex{
 		Store: visionEmbeddingStore,
@@ -638,8 +638,8 @@ func buildSearchStores(cfg *clientConfig, db database.Database, onRebuilt func(c
 			return nil, nil, nil, fmt.Errorf("bm25 store: %w", err)
 		}
 		if cfg.embeddingProvider != nil {
-			textEmbeddingStore = persistence.NewVectorChordEmbeddingStore(db, persistence.TaskNameText, cfg.embeddingProvider, onRebuilt, logger)
-			codeEmbeddingStore = persistence.NewVectorChordEmbeddingStore(db, persistence.TaskNameCode, cfg.embeddingProvider, onRebuilt, logger)
+			textEmbeddingStore = persistence.NewVectorChordEmbeddingStore(db, persistence.TaskNameText, onRebuilt, logger)
+			codeEmbeddingStore = persistence.NewVectorChordEmbeddingStore(db, persistence.TaskNameCode, onRebuilt, logger)
 		}
 	}
 	return

--- a/test/performance/embedding_test.go
+++ b/test/performance/embedding_test.go
@@ -30,21 +30,6 @@ const (
 	embeddingDimension = 768
 )
 
-// fixedDimensionEmbedder is a fake search.Embedder that returns zero vectors
-// of a fixed dimension. It is used in tests that need a specific vector size
-// without a real model.
-type fixedDimensionEmbedder struct {
-	dimension int
-}
-
-func (e fixedDimensionEmbedder) Embed(_ context.Context, items []search.EmbeddingItem) ([][]float64, error) {
-	result := make([][]float64, len(items))
-	for i := range items {
-		result[i] = make([]float64, e.dimension)
-	}
-	return result, nil
-}
-
 // testDB connects to the VectorChord PostgreSQL instance and drops any
 // leftover performance test tables. Returns the database and a cleanup function.
 func testDB(t *testing.T) database.Database {
@@ -125,7 +110,7 @@ func TestEmbeddingPipeline(t *testing.T) {
 	embedder := testEmbedder(t)
 	logger := zerolog.New(os.Stderr).Level(zerolog.WarnLevel)
 
-	store := persistence.NewVectorChordEmbeddingStore(db, "perf", embedder, nil, logger)
+	store := persistence.NewVectorChordEmbeddingStore(db, "perf", nil, logger)
 
 	svc, err := domainservice.NewEmbedding(store, embedder, search.DefaultTokenBudget(), 1)
 	require.NoError(t, err)
@@ -294,7 +279,7 @@ func TestEmbeddingPipelineCPUProfile(t *testing.T) {
 	embedder := testEmbedder(t)
 	logger := zerolog.New(os.Stderr).Level(zerolog.WarnLevel)
 
-	store := persistence.NewVectorChordEmbeddingStore(db, "perf", embedder, nil, logger)
+	store := persistence.NewVectorChordEmbeddingStore(db, "perf", nil, logger)
 
 	svc, err := domainservice.NewEmbedding(store, embedder, search.DefaultTokenBudget(), 1)
 	require.NoError(t, err)
@@ -345,7 +330,7 @@ func TestEmbeddingPipelineMemProfile(t *testing.T) {
 	embedder := testEmbedder(t)
 	logger := zerolog.New(os.Stderr).Level(zerolog.WarnLevel)
 
-	store := persistence.NewVectorChordEmbeddingStore(db, "perf", embedder, nil, logger)
+	store := persistence.NewVectorChordEmbeddingStore(db, "perf", nil, logger)
 
 	svc, err := domainservice.NewEmbedding(store, embedder, search.DefaultTokenBudget(), 1)
 	require.NoError(t, err)
@@ -423,7 +408,6 @@ func TestVectorCopyOverhead(t *testing.T) {
 func TestConcurrentSaveAll(t *testing.T) {
 	ctx := context.Background()
 	db := testDB(t)
-	embedder := fixedDimensionEmbedder{dimension: embeddingDimension}
 	logger := zerolog.New(os.Stderr).Level(zerolog.WarnLevel)
 
 	const tableName = "vectorchord_perf_embeddings"
@@ -436,7 +420,7 @@ func TestConcurrentSaveAll(t *testing.T) {
 		raw := db.Session(ctx)
 		raw.Exec(fmt.Sprintf("DROP INDEX IF EXISTS %s_idx", tableName))
 
-		store := persistence.NewVectorChordEmbeddingStore(db, "perf", embedder, nil, logger)
+		store := persistence.NewVectorChordEmbeddingStore(db, "perf", nil, logger)
 
 		// Pre-build embeddings so goroutines reach ensureIndex at nearly the same time.
 		batches := make([][]search.Embedding, goroutines)
@@ -477,10 +461,9 @@ func TestConcurrentSaveAll(t *testing.T) {
 func TestSaveAllBatching(t *testing.T) {
 	ctx := context.Background()
 	db := testDB(t)
-	embedder := fixedDimensionEmbedder{dimension: embeddingDimension}
 	logger := zerolog.New(os.Stderr).Level(zerolog.WarnLevel)
 
-	store := persistence.NewVectorChordEmbeddingStore(db, "perf", embedder, nil, logger)
+	store := persistence.NewVectorChordEmbeddingStore(db, "perf", nil, logger)
 
 	counts := []int{10, 50, 100, 200, 500}
 	for _, count := range counts {
@@ -506,18 +489,16 @@ func TestSaveAllBatching(t *testing.T) {
 }
 
 // TestDimensionMismatch_RebuildTable verifies that creating a
-// VectorChordEmbeddingStore with a different dimension than the existing
-// table drops the old table, recreates it with the new dimension, and
-// fires the onRebuilt callback.
+// VectorChordEmbeddingStore and writing embeddings with a different dimension
+// than the existing table drops the old table, recreates it with the new
+// dimension, and fires the onRebuilt callback.
 func TestDimensionMismatch_RebuildTable(t *testing.T) {
 	ctx := context.Background()
 	db := testDB(t)
 	logger := zerolog.New(os.Stderr).Level(zerolog.WarnLevel)
 
-	// Create store with dimension 4 and insert data.
-	store := persistence.NewVectorChordEmbeddingStore(
-		db, "perf", fixedDimensionEmbedder{dimension: 4}, nil, logger,
-	)
+	// Create store and insert data with dimension 4.
+	store := persistence.NewVectorChordEmbeddingStore(db, "perf", nil, logger)
 
 	err := store.SaveAll(ctx, []search.Embedding{
 		search.NewEmbedding("s1", []float64{1, 2, 3, 4}),
@@ -529,18 +510,22 @@ func TestDimensionMismatch_RebuildTable(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, int64(2), count, "two rows should exist before rebuild")
 
-	// Re-create with a different dimension and verify callback fires.
+	// New store writing embeddings with dimension 8 triggers rebuild.
 	var rebuilt bool
 	onRebuilt := func(_ context.Context) { rebuilt = true }
-	store2 := persistence.NewVectorChordEmbeddingStore(
-		db, "perf", fixedDimensionEmbedder{dimension: 8}, onRebuilt, logger,
-	)
+	store2 := persistence.NewVectorChordEmbeddingStore(db, "perf", onRebuilt, logger)
 
-	// Trigger lazy init by calling Count.
-	count, err = store2.Count(ctx)
+	// SaveAll with a different dimension triggers table rebuild.
+	err = store2.SaveAll(ctx, []search.Embedding{
+		search.NewEmbedding("s3", []float64{1, 2, 3, 4, 5, 6, 7, 8}),
+	})
 	require.NoError(t, err)
 	require.True(t, rebuilt, "dimension change should trigger onRebuilt callback")
-	require.Equal(t, int64(0), count, "table should be empty after rebuild")
+
+	// Old data is gone, only the new row exists.
+	count, err = store2.Count(ctx)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), count, "only new row should exist after rebuild")
 
 	// Column dimension matches the new value.
 	var dim int
@@ -552,14 +537,4 @@ func TestDimensionMismatch_RebuildTable(t *testing.T) {
 		AND a.attname = 'embedding'`,
 	).Scan(&dim)
 	require.Equal(t, 8, dim, "pg_attribute dimension should match new value")
-
-	// New data can be inserted with the new dimension.
-	err = store2.SaveAll(ctx, []search.Embedding{
-		search.NewEmbedding("s3", []float64{1, 2, 3, 4, 5, 6, 7, 8}),
-	})
-	require.NoError(t, err)
-
-	count, err = store2.Count(ctx)
-	require.NoError(t, err)
-	require.Equal(t, int64(1), count, "should accept data with new dimension")
 }

--- a/test/performance/embedding_test.go
+++ b/test/performance/embedding_test.go
@@ -30,6 +30,21 @@ const (
 	embeddingDimension = 768
 )
 
+// fixedDimensionEmbedder is a fake search.Embedder that returns zero vectors
+// of a fixed dimension. It is used in tests that need a specific vector size
+// without a real model.
+type fixedDimensionEmbedder struct {
+	dimension int
+}
+
+func (e fixedDimensionEmbedder) Embed(_ context.Context, items []search.EmbeddingItem) ([][]float64, error) {
+	result := make([][]float64, len(items))
+	for i := range items {
+		result[i] = make([]float64, e.dimension)
+	}
+	return result, nil
+}
+
 // testDB connects to the VectorChord PostgreSQL instance and drops any
 // leftover performance test tables. Returns the database and a cleanup function.
 func testDB(t *testing.T) database.Database {
@@ -110,10 +125,7 @@ func TestEmbeddingPipeline(t *testing.T) {
 	embedder := testEmbedder(t)
 	logger := zerolog.New(os.Stderr).Level(zerolog.WarnLevel)
 
-	store, _, err := persistence.NewVectorChordEmbeddingStore(
-		ctx, db, "perf", embeddingDimension, logger,
-	)
-	require.NoError(t, err)
+	store := persistence.NewVectorChordEmbeddingStore(db, "perf", embedder, nil, logger)
 
 	svc, err := domainservice.NewEmbedding(store, embedder, search.DefaultTokenBudget(), 1)
 	require.NoError(t, err)
@@ -282,10 +294,7 @@ func TestEmbeddingPipelineCPUProfile(t *testing.T) {
 	embedder := testEmbedder(t)
 	logger := zerolog.New(os.Stderr).Level(zerolog.WarnLevel)
 
-	store, _, err := persistence.NewVectorChordEmbeddingStore(
-		ctx, db, "perf", embeddingDimension, logger,
-	)
-	require.NoError(t, err)
+	store := persistence.NewVectorChordEmbeddingStore(db, "perf", embedder, nil, logger)
 
 	svc, err := domainservice.NewEmbedding(store, embedder, search.DefaultTokenBudget(), 1)
 	require.NoError(t, err)
@@ -336,10 +345,7 @@ func TestEmbeddingPipelineMemProfile(t *testing.T) {
 	embedder := testEmbedder(t)
 	logger := zerolog.New(os.Stderr).Level(zerolog.WarnLevel)
 
-	store, _, err := persistence.NewVectorChordEmbeddingStore(
-		ctx, db, "perf", embeddingDimension, logger,
-	)
-	require.NoError(t, err)
+	store := persistence.NewVectorChordEmbeddingStore(db, "perf", embedder, nil, logger)
 
 	svc, err := domainservice.NewEmbedding(store, embedder, search.DefaultTokenBudget(), 1)
 	require.NoError(t, err)
@@ -417,6 +423,7 @@ func TestVectorCopyOverhead(t *testing.T) {
 func TestConcurrentSaveAll(t *testing.T) {
 	ctx := context.Background()
 	db := testDB(t)
+	embedder := fixedDimensionEmbedder{dimension: embeddingDimension}
 	logger := zerolog.New(os.Stderr).Level(zerolog.WarnLevel)
 
 	const tableName = "vectorchord_perf_embeddings"
@@ -429,10 +436,7 @@ func TestConcurrentSaveAll(t *testing.T) {
 		raw := db.Session(ctx)
 		raw.Exec(fmt.Sprintf("DROP INDEX IF EXISTS %s_idx", tableName))
 
-		store, _, err := persistence.NewVectorChordEmbeddingStore(
-			ctx, db, "perf", embeddingDimension, logger,
-		)
-		require.NoError(t, err)
+		store := persistence.NewVectorChordEmbeddingStore(db, "perf", embedder, nil, logger)
 
 		// Pre-build embeddings so goroutines reach ensureIndex at nearly the same time.
 		batches := make([][]search.Embedding, goroutines)
@@ -473,12 +477,10 @@ func TestConcurrentSaveAll(t *testing.T) {
 func TestSaveAllBatching(t *testing.T) {
 	ctx := context.Background()
 	db := testDB(t)
+	embedder := fixedDimensionEmbedder{dimension: embeddingDimension}
 	logger := zerolog.New(os.Stderr).Level(zerolog.WarnLevel)
 
-	store, _, err := persistence.NewVectorChordEmbeddingStore(
-		ctx, db, "perf", embeddingDimension, logger,
-	)
-	require.NoError(t, err)
+	store := persistence.NewVectorChordEmbeddingStore(db, "perf", embedder, nil, logger)
 
 	counts := []int{10, 50, 100, 200, 500}
 	for _, count := range counts {
@@ -506,18 +508,18 @@ func TestSaveAllBatching(t *testing.T) {
 // TestDimensionMismatch_RebuildTable verifies that creating a
 // VectorChordEmbeddingStore with a different dimension than the existing
 // table drops the old table, recreates it with the new dimension, and
-// returns rebuilt=true.
+// fires the onRebuilt callback.
 func TestDimensionMismatch_RebuildTable(t *testing.T) {
 	ctx := context.Background()
 	db := testDB(t)
 	logger := zerolog.New(os.Stderr).Level(zerolog.WarnLevel)
 
 	// Create store with dimension 4 and insert data.
-	store, rebuilt, err := persistence.NewVectorChordEmbeddingStore(ctx, db, "perf", 4, logger)
-	require.NoError(t, err)
-	require.False(t, rebuilt, "fresh table should not be rebuilt")
+	store := persistence.NewVectorChordEmbeddingStore(
+		db, "perf", fixedDimensionEmbedder{dimension: 4}, nil, logger,
+	)
 
-	err = store.SaveAll(ctx, []search.Embedding{
+	err := store.SaveAll(ctx, []search.Embedding{
 		search.NewEmbedding("s1", []float64{1, 2, 3, 4}),
 		search.NewEmbedding("s2", []float64{5, 6, 7, 8}),
 	})
@@ -527,14 +529,17 @@ func TestDimensionMismatch_RebuildTable(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, int64(2), count, "two rows should exist before rebuild")
 
-	// Re-create with a different dimension.
-	store2, rebuilt2, err := persistence.NewVectorChordEmbeddingStore(ctx, db, "perf", 8, logger)
-	require.NoError(t, err)
-	require.True(t, rebuilt2, "dimension change should trigger rebuild")
+	// Re-create with a different dimension and verify callback fires.
+	var rebuilt bool
+	onRebuilt := func(_ context.Context) { rebuilt = true }
+	store2 := persistence.NewVectorChordEmbeddingStore(
+		db, "perf", fixedDimensionEmbedder{dimension: 8}, onRebuilt, logger,
+	)
 
-	// Old data is gone.
+	// Trigger lazy init by calling Count.
 	count, err = store2.Count(ctx)
 	require.NoError(t, err)
+	require.True(t, rebuilt, "dimension change should trigger onRebuilt callback")
 	require.Equal(t, int64(0), count, "table should be empty after rebuild")
 
 	// Column dimension matches the new value.


### PR DESCRIPTION
## Summary

Further simplification of the VectorChord embedding store by deriving the vector dimension directly from the embeddings passed to `SaveAll`, eliminating the need for an embedder parameter and per-method initialization guards.

### Changes

- **Remove embedder parameter**: No more dimension probe—dimension is derived from `len(embeddings[0].Vector())`
- **Remove per-method guards**: Read methods (Find, Exists, DeleteBy, Count, Search) now use Repository directly without blocking
- **Simplified constructor**: `NewVectorChordEmbeddingStore(db, taskName, onRebuilt, logger)` — 4 params vs 5
- **Table setup deferred**: Only happens on first `SaveAll` call via `ensureTable`
- **Auto-rebuild preserved**: Dimension mismatch detection and table recreation still work, `onRebuilt` callback fires
- **Code reduction**: ~65 lines removed, store is now ~225 lines

The store construction is now purely side-effect-free with zero database access. All setup deferred to first write.

### Testing

- All tests pass: `make check` validates
- Performance tests simplified: removed `fixedDimensionEmbedder` fake
- `TestDimensionMismatch_RebuildTable` updated to test the actual SaveAll-triggered rebuild