### PR TITLE
fix: rescan all repositories with latest commit SHA

### DIFF
--- a/application/service/repository.go
+++ b/application/service/repository.go
@@ -198,13 +198,30 @@ func (s *Repository) Rescan(ctx context.Context, params *RescanParams) error {
 }
 
 func (s *Repository) RescanAll(ctx context.Context) error {
-	repos, err := s.repoStore.Find(ctx)
-	if err != nil {
-		return fmt.Errorf("find repositories: %w", err)
-	}
-	for _, repo := range repos {
-		if err := s.enqueueRescan(ctx, repo, ""); err != nil {
-			return fmt.Errorf("enqueue rescan: %w", err)
+	const pageSize = 500
+	for offset := 0; ; offset += pageSize {
+		repos, err := s.repoStore.Find(ctx, repository.WithLimit(pageSize), repository.WithOffset(offset))
+		if err != nil {
+			return fmt.Errorf("find repositories: %w", err)
+		}
+		for _, repo := range repos {
+			commits, err := s.commitStore.Find(ctx,
+				repository.WithRepoID(repo.ID()),
+				repository.WithOrderDesc("date"),
+				repository.WithLimit(1),
+			)
+			if err != nil {
+				return fmt.Errorf("find latest commit for repo %d: %w", repo.ID(), err)
+			}
+			if len(commits) == 0 {
+				continue
+			}
+			if err := s.enqueueRescan(ctx, repo, commits[0].SHA()); err != nil {
+				return fmt.Errorf("enqueue rescan for repo %d: %w", repo.ID(), err)
+			}
+		}
+		if len(repos) < pageSize {
+			break
 		}
 	}
 	return nil

--- a/application/service/repository_test.go
+++ b/application/service/repository_test.go
@@ -283,10 +283,24 @@ func TestRepository_RescanAll(t *testing.T) {
 	deps := newRepositoryTestDeps(t)
 	ctx := context.Background()
 
-	saveRepoWithDefaults(t, deps, "https://github.com/test/repo1")
-	saveRepoWithDefaults(t, deps, "https://github.com/test/repo2")
+	now := time.Now()
+	repo1 := saveRepoWithDefaults(t, deps, "https://github.com/test/repo1")
+	_, err := deps.stores.commits.Save(ctx, repository.NewCommit(
+		"aaa111", repo1.ID(), "first",
+		repository.NewAuthor("A", "a@a.com"), repository.NewAuthor("A", "a@a.com"),
+		now, now,
+	))
+	require.NoError(t, err)
 
-	err := deps.service.RescanAll(ctx)
+	repo2 := saveRepoWithDefaults(t, deps, "https://github.com/test/repo2")
+	_, err = deps.stores.commits.Save(ctx, repository.NewCommit(
+		"bbb222", repo2.ID(), "first",
+		repository.NewAuthor("B", "b@b.com"), repository.NewAuthor("B", "b@b.com"),
+		now, now,
+	))
+	require.NoError(t, err)
+
+	err = deps.service.RescanAll(ctx)
 	require.NoError(t, err)
 
 	tasks := savedTasks(t, deps)
@@ -297,6 +311,21 @@ func TestRepository_RescanAll(t *testing.T) {
 		}
 	}
 	assert.GreaterOrEqual(t, rescanCount, 2)
+}
+
+func TestRepository_RescanAll_SkipsReposWithNoCommits(t *testing.T) {
+	deps := newRepositoryTestDeps(t)
+	ctx := context.Background()
+
+	saveRepoWithDefaults(t, deps, "https://github.com/test/empty-repo")
+
+	err := deps.service.RescanAll(ctx)
+	require.NoError(t, err)
+
+	tasks := savedTasks(t, deps)
+	for _, tsk := range tasks {
+		assert.NotEqual(t, task.OperationRescanCommit, tsk.Operation())
+	}
 }
 
 func TestRepository_UpdateTrackingConfig(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixed `RescanAll` to work correctly by fetching the latest commit for each repository and rescanning with the specific SHA, rather than passing an empty SHA which causes downstream handlers to fail.

Previously, `RescanAll` would enqueue `RescanCommit` with an empty commit SHA, causing the scanner to fail when looking up the commit object. The fix:

- Paginate through repositories in batches of 500
- For each repo, fetch the latest commit by date
- Pass the actual SHA to the rescan pipeline
- Silently skip repos with no commits (still being cloned)

Also updated tests to verify the behavior with and without commits.