### PR TITLE
fix: cycle idle connections after dropping and recreating vector table

### DIFF
--- a/infrastructure/persistence/embedding_store_vectorchord.go
+++ b/infrastructure/persistence/embedding_store_vectorchord.go
@@ -120,6 +120,14 @@ CREATE TABLE IF NOT EXISTS %s (
 		if err := rawDB.Exec(createTableSQL).Error; err != nil {
 			return errors.Join(ErrVectorInitializationFailed, fmt.Errorf("recreate table: %w", err))
 		}
+
+		// Force pooled connections to close so subsequent queries use fresh
+		// connections that see the new table, not stale cached state.
+		if sqlDB, dbErr := rawDB.DB(); dbErr == nil {
+			sqlDB.SetMaxIdleConns(0)
+			sqlDB.SetMaxIdleConns(10)
+		}
+
 		if s.onRebuilt != nil {
 			s.onRebuilt(ctx)
 		}


### PR DESCRIPTION
## Summary

When a vector table is dropped and recreated due to dimension mismatch, pooled connections may retain stale cached references to the old table schema. This forces a fresh pool by cycling idle connections to zero then back to 10, ensuring subsequent queries see the new table.

## Test plan

- [x] make check passes
- [x] make test passes