### PR TITLE
fix: default max_tokens to 0 (unset)

### DIFF
--- a/infrastructure/enricher/enricher.go
+++ b/infrastructure/enricher/enricher.go
@@ -24,7 +24,7 @@ type ProviderEnricher struct {
 func NewProviderEnricher(generator provider.TextGenerator) *ProviderEnricher {
 	return &ProviderEnricher{
 		generator:   generator,
-		maxTokens:   2048,
+		maxTokens:   0,
 		temperature: 0.7,
 		parallelism: 1,
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,7 +24,7 @@ const (
 	DefaultEndpointMaxRetries        = 5
 	DefaultEndpointInitialDelay      = 2 * time.Second
 	DefaultEndpointBackoffFactor     = 2.0
-	DefaultEndpointMaxTokens         = 4000
+	DefaultEndpointMaxTokens         = 0
 	DefaultPeriodicSyncInterval      = 1800.0 // seconds
 	DefaultPeriodicSyncCheckInterval = 10.0   // seconds
 	DefaultPeriodicSyncRetries       = 3

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -40,8 +40,8 @@ func TestDefaultConstants(t *testing.T) {
 	if DefaultEndpointBackoffFactor != 2.0 {
 		t.Errorf("DefaultEndpointBackoffFactor = %v, want 2.0", DefaultEndpointBackoffFactor)
 	}
-	if DefaultEndpointMaxTokens != 4000 {
-		t.Errorf("DefaultEndpointMaxTokens = %v, want 4000", DefaultEndpointMaxTokens)
+	if DefaultEndpointMaxTokens != 0 {
+		t.Errorf("DefaultEndpointMaxTokens = %v, want 0", DefaultEndpointMaxTokens)
 	}
 	if DefaultPeriodicSyncInterval != 1800.0 {
 		t.Errorf("DefaultPeriodicSyncInterval = %v, want 1800.0", DefaultPeriodicSyncInterval)

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -154,8 +154,8 @@ type EndpointEnv struct {
 	DocumentInstruction string `envconfig:"DOCUMENT_INSTRUCTION"`
 
 	// MaxTokens is the maximum token limit.
-	// Env: *_MAX_TOKENS (default: 4000)
-	MaxTokens int `envconfig:"MAX_TOKENS" default:"4000"`
+	// Env: *_MAX_TOKENS (default: 0)
+	MaxTokens int `envconfig:"MAX_TOKENS" default:"0"`
 
 	// MaxBatchChars is the maximum total characters per embedding batch.
 	// Env: *_MAX_BATCH_CHARS (default: 16000)


### PR DESCRIPTION
## Summary
Stop sending `max_tokens: 2048` on every OpenAI request so vLLM can use its full `max_model_len` budget. The OpenAI provider already omits `max_tokens` when 0 — this change just makes 0 the default.

## Changes
- `DefaultEndpointMaxTokens`: `4000` → `0` (`internal/config/config.go`)
- Enricher default `maxTokens`: `2048` → `0` (`infrastructure/enricher/enricher.go`)
- Env struct tag default: `4000` → `0` (`internal/config/env.go`)
- Updated test assertions to match new defaults

## Testing
`make check` passes for `./internal/config/...` and `./infrastructure/enricher/...`.

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01km00txafwfd22yqdzvkcd5ar/tasks/spt_01kpdt1c3bnmxs3czr4zsrz0zg)

📋 Spec:
- [Requirements](https://github.com/helixml/kodit/blob/helix-specs/design/tasks/001850_kodits-openai-provider/requirements.md)
- [Design](https://github.com/helixml/kodit/blob/helix-specs/design/tasks/001850_kodits-openai-provider/design.md)
- [Tasks](https://github.com/helixml/kodit/blob/helix-specs/design/tasks/001850_kodits-openai-provider/tasks.md)

🚀 Built with [Helix](https://helix.ml)