### PR TITLE
chore: update docs workflow to trigger on README changes and target helix-next pages

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     paths:
-      - docs/**
+      - README.md
 
 jobs:
   cloudflare:
@@ -15,4 +15,4 @@ jobs:
     steps:
       - name: Trigger Cloudflare Pages deployment
         run: |
-          curl -XPOST "https://api.cloudflare.com/client/v4/accounts/${{ secrets.ACCOUNT_ID }}/pages/projects/docs/deployments" -H "Authorization: bearer ${{ secrets.CLOUDFLARE_API_KEY }}"
+          curl -XPOST "https://api.cloudflare.com/client/v4/accounts/${{ secrets.ACCOUNT_ID }}/pages/projects/helix-next/deployments" -H "Authorization: bearer ${{ secrets.CLOUDFLARE_API_KEY }}"


### PR DESCRIPTION
## Summary

- Trigger docs workflow when README.md changes in addition to docs/** directory
- Update Cloudflare Pages deployment target from 'docs' project to 'helix-next' project