### PR TITLE
fix: add mutex to serialize concurrent PDFium WASM access

### DIFF
--- a/infrastructure/rasterization/pdfium.go
+++ b/infrastructure/rasterization/pdfium.go
@@ -3,6 +3,7 @@ package rasterization
 import (
 	"fmt"
 	"image"
+	"sync"
 	"time"
 
 	"github.com/klippa-app/go-pdfium"
@@ -16,9 +17,15 @@ const renderDPI = 150
 // PdfiumRasterizer renders PDF pages using the PDFium library via WebAssembly
 // (Wazero). No CGO or system libraries are required — the PDFium WASM binary
 // is embedded in the go-pdfium module.
+//
+// The underlying pdfium.Pdfium instance wraps a single WASM module whose
+// internal state is not safe for concurrent use: parallel calls corrupt the
+// module's memory and function tables, after which every subsequent call
+// fails until the process restarts. mu serialises all calls into the instance.
 type PdfiumRasterizer struct {
 	pool     pdfium.Pool
 	instance pdfium.Pdfium
+	mu       sync.Mutex
 }
 
 // NewPdfiumRasterizer initialises PDFium via the Wazero WebAssembly runtime
@@ -43,6 +50,9 @@ func NewPdfiumRasterizer() (*PdfiumRasterizer, error) {
 
 // PageCount returns the number of pages in the PDF at the given path.
 func (r *PdfiumRasterizer) PageCount(path string) (int, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
 	doc, err := r.instance.OpenDocument(&requests.OpenDocument{
 		FilePath: &path,
 	})
@@ -66,6 +76,9 @@ func (r *PdfiumRasterizer) PageCount(path string) (int, error) {
 
 // Render returns the given 1-based page of the PDF as an image.
 func (r *PdfiumRasterizer) Render(path string, page int) (image.Image, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
 	doc, err := r.instance.OpenDocument(&requests.OpenDocument{
 		FilePath: &path,
 	})

--- a/infrastructure/rasterization/pdfium_test.go
+++ b/infrastructure/rasterization/pdfium_test.go
@@ -4,6 +4,7 @@ import (
 	"image"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -60,5 +61,49 @@ func TestPdfiumRasterizer_RenderWhitePage(t *testing.T) {
 				t.Fatalf("pixel (%d,%d) is not white: RGBA(%d,%d,%d,%d) — possible corrupted WASM memory", x, y, r, g, b, a)
 			}
 		}
+	}
+}
+
+// TestPdfiumRasterizer_ConcurrentRenders ensures the rasterizer serialises calls
+// to its underlying WASM instance. Without a mutex, concurrent Render/PageCount
+// calls corrupt the shared pdfium.Pdfium state (out-of-bounds memory access,
+// invalid table access, indirect call type mismatch) and every subsequent call
+// 500s until the process restarts.
+func TestPdfiumRasterizer_ConcurrentRenders(t *testing.T) {
+	rast, err := NewPdfiumRasterizer()
+	require.NoError(t, err)
+	defer func() { _ = rast.Close() }()
+
+	path := filepath.Join(t.TempDir(), "white.pdf")
+	require.NoError(t, os.WriteFile(path, whitePDF(), 0o644))
+
+	const goroutines = 8
+	const iterations = 5
+
+	var wg sync.WaitGroup
+	errs := make(chan error, goroutines*iterations*2)
+
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				if _, err := rast.PageCount(path); err != nil {
+					errs <- err
+					return
+				}
+				if _, err := rast.Render(path, 1); err != nil {
+					errs <- err
+					return
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		t.Fatalf("concurrent rasterization failed: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

Adds a `sync.Mutex` to `PdfiumRasterizer` to serialize concurrent access to the shared PDFium WASM instance. The wasm module's internal state gets corrupted when multiple goroutines call `Render()` or `PageCount()` in parallel, causing out-of-bounds memory access and invalid table access errors. Once corrupted, every subsequent render fails until the process restarts.

Fixes the 500s cascade from concurrent PDF page image requests in the vision search flow.

## Test plan

- [x] `TestPdfiumRasterizer_ConcurrentRenders` runs 8 goroutines × 5 iterations of concurrent PageCount+Render calls and verifies all succeed
- [x] All existing 21 rasterization tests pass
- [x] `make check` passes (format, vet, lint)

Assisted by AI. Co-Authored-By: Helix <noreply@helix.ml>