### PR TITLE
fix: prevent deletion of user filestore on repository removal

### DIFF
--- a/application/handler/repository/delete.go
+++ b/application/handler/repository/delete.go
@@ -85,7 +85,7 @@ func (h *Delete) Execute(ctx context.Context, payload map[string]any) error {
 	// Remove working copy from disk
 	tracker.SetCurrent(ctx, 1, "Removing working copy")
 
-	if repo.HasWorkingCopy() {
+	if repo.HasWorkingCopy() && !repo.IsLocal() {
 		clonedPath := repo.WorkingCopy().Path()
 		if err := os.RemoveAll(clonedPath); err != nil {
 			h.logger.Warn().Str("path", clonedPath).Str("error", err.Error()).Msg("failed to remove working copy")

--- a/application/handler/repository/delete_test.go
+++ b/application/handler/repository/delete_test.go
@@ -1,0 +1,108 @@
+package repository
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/helixml/kodit/application/handler"
+	"github.com/helixml/kodit/application/service"
+	"github.com/helixml/kodit/domain/repository"
+	"github.com/helixml/kodit/infrastructure/persistence"
+	"github.com/helixml/kodit/internal/testdb"
+)
+
+func newDeleteHandler(t *testing.T) (*Delete, persistence.RepositoryStore) {
+	t.Helper()
+	db := testdb.New(t)
+	logger := zerolog.New(os.Stdout).Level(zerolog.ErrorLevel)
+
+	repoStore := persistence.NewRepositoryStore(db)
+	commitStore := persistence.NewCommitStore(db)
+	branchStore := persistence.NewBranchStore(db)
+	tagStore := persistence.NewTagStore(db)
+	fileStore := persistence.NewFileStore(db)
+	taskStore := persistence.NewTaskStore(db)
+
+	enrichmentStore := persistence.NewEnrichmentStore(db)
+	associationStore := persistence.NewAssociationStore(db)
+
+	enrichments := service.NewEnrichment(
+		enrichmentStore,
+		associationStore,
+		nil, // bm25 — not reached during delete
+		nil, // code embeddings
+		nil, // text embeddings
+		nil, // vision embeddings
+		nil, // line ranges
+	)
+
+	queue := service.NewQueue(taskStore, logger)
+
+	stores := handler.RepositoryStores{
+		Repositories: repoStore,
+		Commits:      commitStore,
+		Branches:     branchStore,
+		Tags:         tagStore,
+		Files:        fileStore,
+	}
+
+	h := NewDelete(stores, enrichments, queue, &fakeSyncTrackerFactory{}, logger)
+	return h, repoStore
+}
+
+func TestDelete_PreservesLocalFileDirectory(t *testing.T) {
+	ctx := context.Background()
+	h, repoStore := newDeleteHandler(t)
+
+	// Create a temp directory that simulates the user's filestore.
+	userDir := t.TempDir()
+	sentinel := filepath.Join(userDir, "important-file.pdf")
+	require.NoError(t, os.WriteFile(sentinel, []byte("do not delete"), 0644))
+
+	// Register a file:// repository pointing at the user directory.
+	repo, err := repository.NewRepository("file://" + userDir)
+	require.NoError(t, err)
+	repo = repo.WithWorkingCopy(repository.NewWorkingCopy(userDir, "file://"+userDir))
+	repo, err = repoStore.Save(ctx, repo)
+	require.NoError(t, err)
+
+	// Delete the repository.
+	payload := map[string]any{"repository_id": repo.ID()}
+	err = h.Execute(ctx, payload)
+	require.NoError(t, err)
+
+	// The user directory and its contents must still exist.
+	assert.DirExists(t, userDir)
+	assert.FileExists(t, sentinel)
+}
+
+func TestDelete_RemovesClonedDirectory(t *testing.T) {
+	ctx := context.Background()
+	h, repoStore := newDeleteHandler(t)
+
+	// Create a temp directory that simulates a Kodit-managed clone.
+	cloneDir := t.TempDir()
+	sentinel := filepath.Join(cloneDir, "cloned-file.go")
+	require.NoError(t, os.WriteFile(sentinel, []byte("cloned content"), 0644))
+
+	// Register a remote (non-file://) repository with a cloned working copy.
+	repo, err := repository.NewRepository("https://github.com/example/repo.git")
+	require.NoError(t, err)
+	repo = repo.WithWorkingCopy(repository.NewWorkingCopy(cloneDir, "https://github.com/example/repo.git"))
+	repo, err = repoStore.Save(ctx, repo)
+	require.NoError(t, err)
+
+	// Delete the repository.
+	payload := map[string]any{"repository_id": repo.ID()}
+	err = h.Execute(ctx, payload)
+	require.NoError(t, err)
+
+	// The cloned directory should have been removed.
+	assert.NoDirExists(t, cloneDir)
+}

--- a/domain/repository/repository.go
+++ b/domain/repository/repository.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"errors"
+	"strings"
 	"time"
 )
 
@@ -127,6 +128,10 @@ func (r Repository) UpdatedAt() time.Time { return r.updatedAt }
 
 // HasWorkingCopy returns true if a working copy exists.
 func (r Repository) HasWorkingCopy() bool { return !r.workingCopy.IsEmpty() }
+
+// IsLocal returns true if the repository uses a file:// URI, meaning the
+// working copy directory is owned by the user and was not cloned by Kodit.
+func (r Repository) IsLocal() bool { return strings.HasPrefix(r.remoteURL, "file://") }
 
 // HasTrackingConfig returns true if tracking is configured.
 func (r Repository) HasTrackingConfig() bool { return !r.trackingConfig.IsEmpty() }


### PR DESCRIPTION
## Summary

Fixes a critical bug where repository deletion would wipe user files for `file://` URI repositories. When version pruning triggered repository cleanup, Kodit's delete handler called `os.RemoveAll` on the working copy path—which for `file://` repos is the user's actual filestore directory (used in-place without cloning).

This wiped PDFs, guides, and other user-uploaded documents along with the directory itself.

## Changes

- Add `Repository.IsLocal()` domain method to identify `file://` repositories
- Guard `os.RemoveAll` to skip local repositories during deletion
- Add test coverage: `TestDelete_PreservesLocalFileDirectory` and `TestDelete_RemovesClonedDirectory`

## Test plan

- [x] Unit tests pass: `make test PKG=./application/handler/repository/...`
- [x] Domain tests pass: `make test PKG=./domain/repository/...`
- [x] File:// repos no longer have their directories deleted
- [x] Cloned repos still have their directories cleaned up on deletion