### PR TITLE
docs: fix Go HTTP client example and add REPORTING_LOG_TIME_INTERVAL config

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,12 +253,16 @@ import koditclient "github.com/helixml/kodit/clients/go"
 client, err := koditclient.NewClient("https://kodit.example.com")
 
 // List repositories
-resp, err := client.GetApiV1Repositories(ctx)
+resp, err := client.GetRepositories(ctx, nil)
 
 // Search
-resp, err := client.PostApiV1SearchMulti(ctx, koditclient.PostApiV1SearchMultiJSONRequestBody{
-    TextQuery: "create a deployment",
-    TopK:      10,
+text := "create a deployment"
+resp, err := client.PostSearch(ctx, koditclient.PostSearchJSONRequestBody{
+    Data: &koditclient.DtoSearchData{
+        Attributes: &koditclient.DtoSearchAttributes{
+            Text: &text,
+        },
+    },
 })
 ```
 
@@ -418,6 +422,7 @@ kodit serve --env-file .env
 | `SEARCH_LIMIT` | `10` | Default search result limit |
 | `DISABLE_TELEMETRY` | `false` | Disable anonymous usage telemetry |
 | `HTTP_CACHE_DIR` | (empty) | Directory for caching HTTP POST responses to disk; avoids repeated API calls during development |
+| `REPORTING_LOG_TIME_INTERVAL` | `5` | Progress reporting interval in seconds |
 
 ### Embedding Provider
 


### PR DESCRIPTION
## Summary

- Fixed incorrect Go HTTP client method names in the Go HTTP client example: `GetApiV1Repositories` → `GetRepositories(ctx, nil)` and `PostApiV1SearchMulti` → `PostSearch`; corrected request body type from non-existent `PostApiV1SearchMultiJSONRequestBody` to `PostSearchJSONRequestBody` with correct nested `DtoSearchData`/`DtoSearchAttributes` structure
- Added `REPORTING_LOG_TIME_INTERVAL` (default: `5`) to the Server configuration reference table; controls progress reporting interval in seconds

## Tasks completed

- **T15**: Fix Go HTTP client function names and types in README — function names verified against `clients/go/client.gen.go`
- **T16**: Add `REPORTING_LOG_TIME_INTERVAL` to Server config table — field verified against `internal/config/env.go` line 211

## Open questions for human

- **Q3**: What is the `REMOTE_*` config section for? (unanswered)
- **Q4**: Should `LITELLM_CACHE_ENABLED` be documented in the README? (unanswered)
- **Q5**: Should undocumented library `With*` options (WithOpenAIConfig, WithAnthropicConfig, WithModelDir, WithChunkParams, WithVisionEmbedder, etc.) be added to the Library options table?

🤖 Generated with [Claude Code](https://claude.com/claude-code)