### PR TITLE
docs: fix library search example and add missing search options

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,12 +253,16 @@ import koditclient "github.com/helixml/kodit/clients/go"
 client, err := koditclient.NewClient("https://kodit.example.com")
 
 // List repositories
-resp, err := client.GetApiV1Repositories(ctx)
+resp, err := client.GetRepositories(ctx, nil)
 
 // Search
-resp, err := client.PostApiV1SearchMulti(ctx, koditclient.PostApiV1SearchMultiJSONRequestBody{
-    TextQuery: "create a deployment",
-    TopK:      10,
+text := "create a deployment"
+resp, err := client.PostSearch(ctx, koditclient.PostSearchJSONRequestBody{
+    Data: &koditclient.DtoSearchData{
+        Attributes: &koditclient.DtoSearchAttributes{
+            Text: &text,
+        },
+    },
 })
 ```
 
@@ -418,6 +422,7 @@ kodit serve --env-file .env
 | `SEARCH_LIMIT` | `10` | Default search result limit |
 | `DISABLE_TELEMETRY` | `false` | Disable anonymous usage telemetry |
 | `HTTP_CACHE_DIR` | (empty) | Directory for caching HTTP POST responses to disk; avoids repeated API calls during development |
+| `REPORTING_LOG_TIME_INTERVAL` | `5` | Progress reporting interval in seconds |
 
 ### Embedding Provider
 

--- a/README.md
+++ b/README.md
@@ -205,8 +205,8 @@ results, err := client.Search.Query(ctx, "create a deployment",
     service.WithLimit(10),
 )
 
-for _, snippet := range results.Snippets() {
-    fmt.Println(snippet.Path(), snippet.Name())
+for _, result := range results.Enrichments() {
+    fmt.Println(result.Subtype(), result.Content())
 }
 ```
 
@@ -238,6 +238,9 @@ for _, snippet := range results.Snippets() {
 | `WithLanguages(langs...)` | Filter by programming languages |
 | `WithRepositories(ids...)` | Filter by repository IDs |
 | `WithMinScore(score)` | Minimum score threshold |
+| `WithEnrichmentTypes(types...)` | Filter results to specific enrichment types |
+| `WithSnippets(include)` | Include code snippets in results |
+| `WithDocuments(include)` | Include enrichment documents in results |
 
 ### Go HTTP client
 


### PR DESCRIPTION
## Summary

- Fix Go library usage example: replace non-existent `results.Snippets()` with `results.Enrichments()` and fix `snippet.Path()/Name()` to `result.Subtype()/result.Content()` (T17)
- Add `WithEnrichmentTypes`, `WithSnippets`, and `WithDocuments` to the Search options table — these exist in `application/service/search.go` but were missing from the README (T18)

## Tasks completed

- **T17**: Fix Go library search example to use correct SearchResult API
- **T18**: Add WithEnrichmentTypes, WithSnippets, WithDocuments to Search options table