### PR TITLE
fix: replace LIMIT-based dedupe with chunked lookup to handle repos with >1000 enrichments

### DIFF
--- a/application/handler/indexing/create_embeddings.go
+++ b/application/handler/indexing/create_embeddings.go
@@ -126,19 +126,14 @@ func (h *CreateCodeEmbeddings) filterNew(ctx context.Context, enrichments []enri
 		ids[i] = strconv.FormatInt(e.ID(), 10)
 	}
 
-	found, err := h.codeIndex.Store.Find(ctx, search.WithSnippetIDs(ids), repository.WithLimit(search.MaxSnippetIDsPerFind))
+	existing, err := search.ExistingSnippetIDs(ctx, h.codeIndex.Store, ids)
 	if err != nil {
 		return nil, err
 	}
 
-	existing := make(map[string]bool, len(found))
-	for _, emb := range found {
-		existing[emb.SnippetID()] = true
-	}
-
 	result := make([]enrichment.Enrichment, 0, len(enrichments))
 	for i, e := range enrichments {
-		if !existing[ids[i]] {
+		if _, ok := existing[ids[i]]; !ok {
 			result = append(result, e)
 		}
 	}

--- a/application/handler/indexing/create_page_image_embeddings.go
+++ b/application/handler/indexing/create_page_image_embeddings.go
@@ -235,19 +235,14 @@ func (h *CreatePageImageEmbeddings) filterNew(ctx context.Context, enrichments [
 		ids[i] = strconv.FormatInt(e.ID(), 10)
 	}
 
-	found, err := h.store.Find(ctx, search.WithSnippetIDs(ids), repository.WithLimit(search.MaxSnippetIDsPerFind))
+	existing, err := search.ExistingSnippetIDs(ctx, h.store, ids)
 	if err != nil {
 		return nil, err
 	}
 
-	existing := make(map[string]bool, len(found))
-	for _, emb := range found {
-		existing[emb.SnippetID()] = true
-	}
-
 	result := make([]enrichment.Enrichment, 0, len(enrichments))
 	for i, e := range enrichments {
-		if !existing[ids[i]] {
+		if _, ok := existing[ids[i]]; !ok {
 			result = append(result, e)
 		}
 	}

--- a/application/handler/indexing/create_summary_embeddings.go
+++ b/application/handler/indexing/create_summary_embeddings.go
@@ -152,14 +152,9 @@ func (h *CreateSummaryEmbeddings) filterNewEnrichments(ctx context.Context, enri
 		return nil, nil
 	}
 
-	found, err := h.textIndex.Store.Find(ctx, search.WithSnippetIDs(snippetSHAs), repository.WithLimit(search.MaxSnippetIDsPerFind))
+	existing, err := search.ExistingSnippetIDs(ctx, h.textIndex.Store, snippetSHAs)
 	if err != nil {
 		return nil, err
-	}
-
-	existing := make(map[string]bool, len(found))
-	for _, emb := range found {
-		existing[emb.SnippetID()] = true
 	}
 
 	result := make([]enrichment.Enrichment, 0, len(enrichments))
@@ -171,7 +166,7 @@ func (h *CreateSummaryEmbeddings) filterNewEnrichments(ctx context.Context, enri
 		if snippetSHA == "" {
 			continue
 		}
-		if !existing[snippetSHA] {
+		if _, ok := existing[snippetSHA]; !ok {
 			result = append(result, e)
 		}
 	}

--- a/application/handler/indexing/dedupe_test.go
+++ b/application/handler/indexing/dedupe_test.go
@@ -1,0 +1,170 @@
+package indexing
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/helixml/kodit/application/handler"
+	"github.com/helixml/kodit/domain/enrichment"
+	"github.com/helixml/kodit/domain/repository"
+	"github.com/helixml/kodit/domain/search"
+	"github.com/helixml/kodit/infrastructure/persistence"
+	"github.com/helixml/kodit/internal/testdb"
+)
+
+// dedupingEmbeddingStore is a fake search.EmbeddingStore that simulates
+// PostgreSQL semantics: it returns matches for snippet IDs in the IN
+// condition, and honours the LIMIT option by truncating the result set.
+// This mirrors how the production store responds, so tests can exercise
+// the dedupe logic for repos with more than MaxSnippetIDsPerFind snippets.
+type dedupingEmbeddingStore struct {
+	mu       sync.Mutex
+	existing map[string]struct{}
+	saved    []search.Embedding
+}
+
+func (s *dedupingEmbeddingStore) SaveAll(_ context.Context, embeddings []search.Embedding) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.saved = append(s.saved, embeddings...)
+	for _, e := range embeddings {
+		s.existing[e.SnippetID()] = struct{}{}
+	}
+	return nil
+}
+
+func (s *dedupingEmbeddingStore) Find(_ context.Context, options ...repository.Option) ([]search.Embedding, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	q := repository.Build(options...)
+	ids := search.SnippetIDsFrom(q)
+	var result []search.Embedding
+	for _, id := range ids {
+		if _, ok := s.existing[id]; ok {
+			result = append(result, search.NewEmbedding(id, nil))
+		}
+	}
+	if limit := q.LimitValue(); limit > 0 && len(result) > limit {
+		result = result[:limit]
+	}
+	return result, nil
+}
+
+func (s *dedupingEmbeddingStore) Search(_ context.Context, _ ...repository.Option) ([]search.Result, error) {
+	return nil, nil
+}
+
+func (s *dedupingEmbeddingStore) Exists(_ context.Context, _ ...repository.Option) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.existing) > 0, nil
+}
+
+func (s *dedupingEmbeddingStore) DeleteBy(_ context.Context, _ ...repository.Option) error {
+	return nil
+}
+
+func TestCreateCodeEmbeddings_DeduplicatesBeyondMaxSnippetIDsPerFind(t *testing.T) {
+	ctx := context.Background()
+	logger := zerolog.New(zerolog.NewTestWriter(t)).Level(zerolog.ErrorLevel)
+
+	db := testdb.New(t)
+	enrichmentStore := persistence.NewEnrichmentStore(db)
+	associationStore := persistence.NewAssociationStore(db)
+
+	commitSHA := "fff666aaa777"
+
+	// Create more chunk enrichments than the per-Find cap, all attached to
+	// the same commit. The point is to exercise dedupe across a number of
+	// snippets that exceeds MaxSnippetIDsPerFind in a single round.
+	total := search.MaxSnippetIDsPerFind + 25
+	existing := make(map[string]struct{}, total)
+	for i := range total {
+		saved, err := enrichmentStore.Save(ctx, enrichment.NewChunkEnrichment("chunk "+strconv.Itoa(i)))
+		require.NoError(t, err)
+		_, err = associationStore.Save(ctx, enrichment.CommitAssociation(saved.ID(), commitSHA))
+		require.NoError(t, err)
+		existing[strconv.FormatInt(saved.ID(), 10)] = struct{}{}
+	}
+
+	store := &dedupingEmbeddingStore{existing: existing}
+	rec := &recordingEmbedding{}
+	h, err := NewCreateCodeEmbeddings(
+		handler.VectorIndex{Embedding: rec, Store: store},
+		enrichmentStore,
+		&fakeTrackerFactory{},
+		logger,
+		enrichment.SubtypeChunk,
+	)
+	require.NoError(t, err)
+
+	payload := map[string]any{
+		"repository_id": int64(1),
+		"commit_sha":    commitSHA,
+	}
+	err = h.Execute(ctx, payload)
+	require.NoError(t, err)
+
+	assert.Empty(t, rec.documents(),
+		"all %d enrichments already have embeddings; nothing should be re-embedded", total)
+	assert.Empty(t, store.saved,
+		"no new embeddings should be saved when all enrichments already exist")
+}
+
+func TestCreateSummaryEmbeddings_DeduplicatesBeyondMaxSnippetIDsPerFind(t *testing.T) {
+	ctx := context.Background()
+	logger := zerolog.New(zerolog.NewTestWriter(t)).Level(zerolog.ErrorLevel)
+
+	db := testdb.New(t)
+	enrichmentStore := persistence.NewEnrichmentStore(db)
+	associationStore := persistence.NewAssociationStore(db)
+
+	commitSHA := "ggg777bbb888"
+
+	total := search.MaxSnippetIDsPerFind + 25
+	existing := make(map[string]struct{}, total)
+	for i := range total {
+		// Create snippet to act as the snippet ID target.
+		snippet, err := enrichmentStore.Save(ctx, enrichment.NewSnippetEnrichment("snippet "+strconv.Itoa(i)))
+		require.NoError(t, err)
+		snippetSHA := strconv.FormatInt(snippet.ID(), 10)
+
+		summary, err := enrichmentStore.Save(ctx, enrichment.NewSnippetSummary("summary "+strconv.Itoa(i)))
+		require.NoError(t, err)
+		_, err = associationStore.Save(ctx, enrichment.CommitAssociation(summary.ID(), commitSHA))
+		require.NoError(t, err)
+		_, err = associationStore.Save(ctx, enrichment.SnippetAssociation(summary.ID(), snippetSHA))
+		require.NoError(t, err)
+
+		existing[snippetSHA] = struct{}{}
+	}
+
+	store := &dedupingEmbeddingStore{existing: existing}
+	rec := &recordingEmbedding{}
+	h, err := NewCreateSummaryEmbeddings(
+		handler.VectorIndex{Embedding: rec, Store: store},
+		enrichmentStore,
+		associationStore,
+		&fakeTrackerFactory{},
+		logger,
+	)
+	require.NoError(t, err)
+
+	payload := map[string]any{
+		"repository_id": int64(1),
+		"commit_sha":    commitSHA,
+	}
+	err = h.Execute(ctx, payload)
+	require.NoError(t, err)
+
+	assert.Empty(t, rec.documents(),
+		"all %d summary enrichments already have embeddings; nothing should be re-embedded", total)
+	assert.Empty(t, store.saved,
+		"no new summary embeddings should be saved when all enrichments already exist")
+}

--- a/domain/search/dedupe.go
+++ b/domain/search/dedupe.go
@@ -1,0 +1,22 @@
+package search
+
+import "context"
+
+// ExistingSnippetIDs returns the subset of ids whose snippet IDs already
+// have embeddings in the store. The lookup is split into chunks of
+// MaxSnippetIDsPerFind so the IN-clause bind parameters stay within the
+// PostgreSQL 65535 limit, and the matches across chunks are unioned.
+func ExistingSnippetIDs(ctx context.Context, store EmbeddingStore, ids []string) (map[string]struct{}, error) {
+	existing := make(map[string]struct{}, len(ids))
+	for start := 0; start < len(ids); start += MaxSnippetIDsPerFind {
+		end := min(start+MaxSnippetIDsPerFind, len(ids))
+		found, err := store.Find(ctx, WithSnippetIDs(ids[start:end]))
+		if err != nil {
+			return nil, err
+		}
+		for _, e := range found {
+			existing[e.SnippetID()] = struct{}{}
+		}
+	}
+	return existing, nil
+}

--- a/domain/service/embedding.go
+++ b/domain/service/embedding.go
@@ -80,14 +80,9 @@ func (s *EmbeddingService) Index(ctx context.Context, request search.IndexReques
 		ids[i] = doc.SnippetID()
 	}
 
-	found, err := s.store.Find(ctx, search.WithSnippetIDs(ids), repository.WithLimit(search.MaxSnippetIDsPerFind))
+	existing, err := search.ExistingSnippetIDs(ctx, s.store, ids)
 	if err != nil {
 		return fmt.Errorf("check existing: %w", err)
-	}
-
-	existing := make(map[string]struct{}, len(found))
-	for _, emb := range found {
-		existing[emb.SnippetID()] = struct{}{}
 	}
 
 	var toEmbed []search.Document

--- a/domain/service/embedding_test.go
+++ b/domain/service/embedding_test.go
@@ -71,6 +71,9 @@ func (f *fakeEmbeddingStore) Find(_ context.Context, options ...repository.Optio
 			result = append(result, e)
 		}
 	}
+	if limit := q.LimitValue(); limit > 0 && len(result) > limit {
+		result = result[:limit]
+	}
 	return result, nil
 }
 
@@ -221,6 +224,31 @@ func TestEmbeddingService_Index_Deduplication(t *testing.T) {
 
 	require.Len(t, embedder.calls, 1)
 	require.Len(t, embedder.calls[0], 2, "only 2 new documents embedded")
+}
+
+func TestEmbeddingService_Index_DeduplicatesBeyondMaxSnippetIDsPerFind(t *testing.T) {
+	embedder := &fakeEmbedder{errAt: -1}
+
+	total := search.MaxSnippetIDsPerFind + 50
+	existing := make(map[string]search.Embedding, total)
+	documents := make([]search.Document, total)
+	for i := range total {
+		id := fmt.Sprintf("id-%d", i)
+		existing[id] = search.NewEmbedding(id, []float64{0.1, 0.2, 0.3})
+		documents[i] = search.NewDocument(id, fmt.Sprintf("text %d", i))
+	}
+
+	store := &fakeEmbeddingStore{existing: existing, saveErr: -1}
+	svc, err := NewEmbedding(store, embedder, testBudget(), 1)
+	require.NoError(t, err)
+
+	err = svc.Index(context.Background(), search.NewIndexRequest(documents))
+	require.NoError(t, err)
+
+	require.Empty(t, embedder.calls,
+		"all %d documents already exist, embedder must not be called", total)
+	require.Empty(t, store.saved,
+		"all %d documents already exist, save must not be called", total)
 }
 
 func TestEmbeddingService_Index_EmbedErrorMidBatch(t *testing.T) {

--- a/infrastructure/persistence/embedding_store_vectorchord_dedupe_test.go
+++ b/infrastructure/persistence/embedding_store_vectorchord_dedupe_test.go
@@ -1,0 +1,74 @@
+//go:build integration
+
+package persistence
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/helixml/kodit/domain/search"
+	"github.com/helixml/kodit/internal/database"
+)
+
+// TestVectorChordEmbeddingStore_ExistingSnippetIDsAcrossChunks confirms that
+// search.ExistingSnippetIDs correctly returns ALL existing IDs even when the
+// input set exceeds search.MaxSnippetIDsPerFind. This guards the regression
+// from issue #554, where a single Find with WithLimit(N) silently dropped
+// matches beyond N and re-embedded the overflow on every cycle.
+//
+//	VECTORCHORD_TEST_URL="postgresql://postgres:mysecretpassword@localhost:5432/kodit" \
+//	  go test -tags integration -v -run TestVectorChordEmbeddingStore_ExistingSnippetIDsAcrossChunks \
+//	  ./infrastructure/persistence/
+func TestVectorChordEmbeddingStore_ExistingSnippetIDsAcrossChunks(t *testing.T) {
+	dsn := os.Getenv("VECTORCHORD_TEST_URL")
+	if dsn == "" {
+		t.Skip("VECTORCHORD_TEST_URL not set")
+	}
+
+	ctx := context.Background()
+	logger := zerolog.New(zerolog.NewTestWriter(t))
+
+	db, err := database.NewDatabase(ctx, dsn)
+	require.NoError(t, err)
+
+	taskName := TaskName("dedupe_live_test")
+	tableName := fmt.Sprintf("vectorchord_%s_embeddings", taskName)
+	dropTable := func() { db.Session(ctx).Exec(fmt.Sprintf("DROP TABLE IF EXISTS %s", tableName)) }
+
+	dropTable()
+	defer func() {
+		dropTable()
+		_ = db.Close()
+	}()
+
+	store := NewVectorChordEmbeddingStore(db, taskName, nil, logger)
+
+	// Save more embeddings than the per-Find chunk size so dedupe must span
+	// multiple lookups. The exact count mirrors the production scenario from
+	// the bug report (a repo with thousands of chunk enrichments).
+	total := search.MaxSnippetIDsPerFind*2 + 25
+	embeddings := make([]search.Embedding, total)
+	ids := make([]string, total)
+	for i := range total {
+		ids[i] = strconv.Itoa(i + 1)
+		embeddings[i] = search.NewEmbedding(ids[i], []float64{0.1, 0.2, 0.3, 0.4})
+	}
+	require.NoError(t, store.SaveAll(ctx, embeddings))
+
+	existing, err := search.ExistingSnippetIDs(ctx, store, ids)
+	require.NoError(t, err)
+
+	assert.Len(t, existing, total,
+		"all %d snippet IDs must be reported as existing — bug #554 regression check", total)
+	for _, id := range ids {
+		_, ok := existing[id]
+		assert.True(t, ok, "id %s must be in the existing set", id)
+	}
+}


### PR DESCRIPTION
## Summary

Replace buggy single-Find with LIMIT cap at four embedding dedupe sites. The previous code applied MaxSnippetIDsPerFind as an output LIMIT, silently dropping matches beyond 1000. Repos with >1000 enrichments re-embedded the overflow on every indexing cycle, indefinitely.

New `search.ExistingSnippetIDs()` chunks the lookup across multiple Find calls (each up to 1000 IDs), unions the results, and avoids both the output-truncation bug and PostgreSQL's 65535 bind-parameter limit.

Fixes #554.