### PR TITLE
fix: dedupe BM25 indexing to skip re-indexing stable commits

### DIFF
--- a/application/handler/indexing/create_bm25.go
+++ b/application/handler/indexing/create_bm25.go
@@ -63,10 +63,19 @@ func (h *CreateBM25Index) Execute(ctx context.Context, payload map[string]any) e
 		return nil
 	}
 
-	tracker.SetTotal(ctx, len(enrichments))
+	newEnrichments, err := h.filterNew(ctx, enrichments)
+	if err != nil {
+		h.logger.Error().Str("error", err.Error()).Msg("failed to filter new enrichments")
+		return err
+	}
 
-	documents := make([]search.Document, 0, len(enrichments))
-	for _, e := range enrichments {
+	if len(newEnrichments) == 0 {
+		tracker.Skip(ctx, "All snippets already have BM25 entries")
+		return nil
+	}
+
+	documents := make([]search.Document, 0, len(newEnrichments))
+	for _, e := range newEnrichments {
 		if e.Content() != "" {
 			doc := search.NewDocument(strconv.FormatInt(e.ID(), 10), e.Content())
 			documents = append(documents, doc)
@@ -78,15 +87,38 @@ func (h *CreateBM25Index) Execute(ctx context.Context, payload map[string]any) e
 		return nil
 	}
 
+	tracker.SetTotal(ctx, len(documents))
+
 	request := search.NewIndexRequest(documents)
 	if err := h.bm25Service.Index(ctx, request); err != nil {
 		h.logger.Error().Str("error", err.Error()).Msg("failed to index documents")
 		return err
 	}
 
-	tracker.SetCurrent(ctx, len(enrichments), "BM25 index created for commit")
+	tracker.SetCurrent(ctx, len(documents), "BM25 index created for commit")
 
 	h.logger.Info().Int("documents", len(documents)).Str("commit", handler.ShortSHA(cp.CommitSHA())).Msg("BM25 index created")
 
 	return nil
+}
+
+func (h *CreateBM25Index) filterNew(ctx context.Context, enrichments []enrichment.Enrichment) ([]enrichment.Enrichment, error) {
+	ids := make([]string, len(enrichments))
+	for i, e := range enrichments {
+		ids[i] = strconv.FormatInt(e.ID(), 10)
+	}
+
+	existing, err := h.bm25Service.ExistingIDs(ctx, ids)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]enrichment.Enrichment, 0, len(enrichments))
+	for i, e := range enrichments {
+		if _, ok := existing[ids[i]]; !ok {
+			result = append(result, e)
+		}
+	}
+
+	return result, nil
 }

--- a/application/handler/indexing/create_bm25.go
+++ b/application/handler/indexing/create_bm25.go
@@ -63,7 +63,7 @@ func (h *CreateBM25Index) Execute(ctx context.Context, payload map[string]any) e
 		return nil
 	}
 
-	newEnrichments, err := h.filterNew(ctx, enrichments)
+	newEnrichments, err := filterNewEnrichments(ctx, h.bm25Service.ExistingIDs, enrichments)
 	if err != nil {
 		h.logger.Error().Str("error", err.Error()).Msg("failed to filter new enrichments")
 		return err
@@ -100,25 +100,4 @@ func (h *CreateBM25Index) Execute(ctx context.Context, payload map[string]any) e
 	h.logger.Info().Int("documents", len(documents)).Str("commit", handler.ShortSHA(cp.CommitSHA())).Msg("BM25 index created")
 
 	return nil
-}
-
-func (h *CreateBM25Index) filterNew(ctx context.Context, enrichments []enrichment.Enrichment) ([]enrichment.Enrichment, error) {
-	ids := make([]string, len(enrichments))
-	for i, e := range enrichments {
-		ids[i] = strconv.FormatInt(e.ID(), 10)
-	}
-
-	existing, err := h.bm25Service.ExistingIDs(ctx, ids)
-	if err != nil {
-		return nil, err
-	}
-
-	result := make([]enrichment.Enrichment, 0, len(enrichments))
-	for i, e := range enrichments {
-		if _, ok := existing[ids[i]]; !ok {
-			result = append(result, e)
-		}
-	}
-
-	return result, nil
 }

--- a/application/handler/indexing/create_bm25_test.go
+++ b/application/handler/indexing/create_bm25_test.go
@@ -1,0 +1,199 @@
+package indexing
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/helixml/kodit/application/handler"
+	"github.com/helixml/kodit/domain/enrichment"
+	"github.com/helixml/kodit/domain/repository"
+	"github.com/helixml/kodit/domain/search"
+	domainservice "github.com/helixml/kodit/domain/service"
+	"github.com/helixml/kodit/domain/task"
+	"github.com/helixml/kodit/infrastructure/persistence"
+	"github.com/helixml/kodit/internal/testdb"
+)
+
+// dedupingBM25Store is a fake search.BM25Store that simulates the
+// production stores: it tracks already-indexed snippet IDs and reports
+// them via ExistingIDs.
+type dedupingBM25Store struct {
+	mu       sync.Mutex
+	existing map[string]struct{}
+	indexed  []search.Document
+}
+
+func (s *dedupingBM25Store) Index(_ context.Context, req search.IndexRequest) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, doc := range req.Documents() {
+		if _, ok := s.existing[doc.SnippetID()]; ok {
+			continue
+		}
+		s.indexed = append(s.indexed, doc)
+		s.existing[doc.SnippetID()] = struct{}{}
+	}
+	return nil
+}
+
+func (s *dedupingBM25Store) Find(_ context.Context, _ ...repository.Option) ([]search.Result, error) {
+	return nil, nil
+}
+
+func (s *dedupingBM25Store) ExistingIDs(_ context.Context, ids []string) (map[string]struct{}, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	result := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		if _, ok := s.existing[id]; ok {
+			result[id] = struct{}{}
+		}
+	}
+	return result, nil
+}
+
+func (s *dedupingBM25Store) DeleteBy(_ context.Context, _ ...repository.Option) error {
+	return nil
+}
+
+// recordingTracker captures Skip and SetCurrent calls so tests can
+// verify that the handler emits the right state transition.
+type recordingTracker struct {
+	skipped     bool
+	skipMessage string
+	currentSet  bool
+	currentN    int
+}
+
+func (r *recordingTracker) SetTotal(_ context.Context, _ int) {}
+func (r *recordingTracker) SetCurrent(_ context.Context, n int, _ string) {
+	r.currentSet = true
+	r.currentN = n
+}
+func (r *recordingTracker) Skip(_ context.Context, msg string) {
+	r.skipped = true
+	r.skipMessage = msg
+}
+func (r *recordingTracker) Fail(_ context.Context, _ string) {}
+func (r *recordingTracker) Complete(_ context.Context)       {}
+
+type recordingTrackerFactory struct {
+	tracker *recordingTracker
+}
+
+func (f *recordingTrackerFactory) ForOperation(_ task.Operation, _ map[string]any) handler.Tracker {
+	return f.tracker
+}
+
+func TestCreateBM25Index_SkipsWhenAllEnrichmentsAlreadyIndexed(t *testing.T) {
+	ctx := context.Background()
+	logger := zerolog.New(zerolog.NewTestWriter(t)).Level(zerolog.ErrorLevel)
+
+	db := testdb.New(t)
+	enrichmentStore := persistence.NewEnrichmentStore(db)
+	associationStore := persistence.NewAssociationStore(db)
+
+	commitSHA := "stable000111"
+
+	// Create chunk enrichments attached to the commit, and pre-populate the
+	// BM25 store so every snippet is already indexed. A real instance hitting
+	// a stable commit on every cycle is the scenario from issue #555.
+	existing := make(map[string]struct{})
+	for i := range 5 {
+		saved, err := enrichmentStore.Save(ctx, enrichment.NewChunkEnrichment("chunk "+strconv.Itoa(i)))
+		require.NoError(t, err)
+		_, err = associationStore.Save(ctx, enrichment.CommitAssociation(saved.ID(), commitSHA))
+		require.NoError(t, err)
+		existing[strconv.FormatInt(saved.ID(), 10)] = struct{}{}
+	}
+
+	store := &dedupingBM25Store{existing: existing}
+	bm25Service, err := domainservice.NewBM25(store)
+	require.NoError(t, err)
+
+	tracker := &recordingTracker{}
+	h := NewCreateBM25Index(
+		bm25Service,
+		enrichmentStore,
+		&recordingTrackerFactory{tracker: tracker},
+		logger,
+		enrichment.SubtypeChunk,
+	)
+
+	payload := map[string]any{
+		"repository_id": int64(1),
+		"commit_sha":    commitSHA,
+	}
+	require.NoError(t, h.Execute(ctx, payload))
+
+	assert.True(t, tracker.skipped,
+		"handler must emit Skip when every enrichment already has a BM25 entry")
+	assert.False(t, tracker.currentSet,
+		"handler must not emit SetCurrent (which marks the operation completed) when nothing was indexed")
+	assert.Empty(t, store.indexed,
+		"no new documents should be sent to the BM25 store when all are duplicates")
+}
+
+func TestCreateBM25Index_OnlyIndexesNewEnrichments(t *testing.T) {
+	ctx := context.Background()
+	logger := zerolog.New(zerolog.NewTestWriter(t)).Level(zerolog.ErrorLevel)
+
+	db := testdb.New(t)
+	enrichmentStore := persistence.NewEnrichmentStore(db)
+	associationStore := persistence.NewAssociationStore(db)
+
+	commitSHA := "mixedcafebab1"
+
+	// Five enrichments: the first three are already in the BM25 store,
+	// the last two are new and must be indexed.
+	existing := make(map[string]struct{})
+	allIDs := make([]string, 0, 5)
+	for i := range 5 {
+		saved, err := enrichmentStore.Save(ctx, enrichment.NewChunkEnrichment("chunk "+strconv.Itoa(i)))
+		require.NoError(t, err)
+		_, err = associationStore.Save(ctx, enrichment.CommitAssociation(saved.ID(), commitSHA))
+		require.NoError(t, err)
+		id := strconv.FormatInt(saved.ID(), 10)
+		allIDs = append(allIDs, id)
+		if i < 3 {
+			existing[id] = struct{}{}
+		}
+	}
+
+	store := &dedupingBM25Store{existing: existing}
+	bm25Service, err := domainservice.NewBM25(store)
+	require.NoError(t, err)
+
+	tracker := &recordingTracker{}
+	h := NewCreateBM25Index(
+		bm25Service,
+		enrichmentStore,
+		&recordingTrackerFactory{tracker: tracker},
+		logger,
+		enrichment.SubtypeChunk,
+	)
+
+	payload := map[string]any{
+		"repository_id": int64(1),
+		"commit_sha":    commitSHA,
+	}
+	require.NoError(t, h.Execute(ctx, payload))
+
+	assert.False(t, tracker.skipped,
+		"handler must not Skip when there are new enrichments to index")
+	assert.Len(t, store.indexed, 2,
+		"only the two new enrichments should reach the BM25 store")
+
+	indexedIDs := make(map[string]struct{}, len(store.indexed))
+	for _, doc := range store.indexed {
+		indexedIDs[doc.SnippetID()] = struct{}{}
+	}
+	assert.Contains(t, indexedIDs, allIDs[3])
+	assert.Contains(t, indexedIDs, allIDs[4])
+}

--- a/application/handler/indexing/create_embeddings.go
+++ b/application/handler/indexing/create_embeddings.go
@@ -76,7 +76,9 @@ func (h *CreateCodeEmbeddings) Execute(ctx context.Context, payload map[string]a
 		return nil
 	}
 
-	newEnrichments, err := h.filterNew(ctx, enrichments)
+	newEnrichments, err := filterNewEnrichments(ctx, func(ctx context.Context, ids []string) (map[string]struct{}, error) {
+		return search.ExistingSnippetIDs(ctx, h.codeIndex.Store, ids)
+	}, enrichments)
 	if err != nil {
 		h.logger.Error().Str("error", err.Error()).Msg("failed to filter new enrichments")
 		return err
@@ -118,25 +120,4 @@ func (h *CreateCodeEmbeddings) Execute(ctx context.Context, payload map[string]a
 	h.logger.Info().Int("documents", len(documents)).Str("commit", handler.ShortSHA(cp.CommitSHA())).Msg("code embeddings created")
 
 	return nil
-}
-
-func (h *CreateCodeEmbeddings) filterNew(ctx context.Context, enrichments []enrichment.Enrichment) ([]enrichment.Enrichment, error) {
-	ids := make([]string, len(enrichments))
-	for i, e := range enrichments {
-		ids[i] = strconv.FormatInt(e.ID(), 10)
-	}
-
-	existing, err := search.ExistingSnippetIDs(ctx, h.codeIndex.Store, ids)
-	if err != nil {
-		return nil, err
-	}
-
-	result := make([]enrichment.Enrichment, 0, len(enrichments))
-	for i, e := range enrichments {
-		if _, ok := existing[ids[i]]; !ok {
-			result = append(result, e)
-		}
-	}
-
-	return result, nil
 }

--- a/application/handler/indexing/filter_new.go
+++ b/application/handler/indexing/filter_new.go
@@ -1,0 +1,34 @@
+package indexing
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/helixml/kodit/domain/enrichment"
+)
+
+// existingIDsLookup reports which of the given string IDs already have
+// entries in the underlying index.
+type existingIDsLookup func(ctx context.Context, ids []string) (map[string]struct{}, error)
+
+// filterNewEnrichments returns the subset of enrichments whose IDs are not
+// yet present in the index, according to the lookup.
+func filterNewEnrichments(ctx context.Context, lookup existingIDsLookup, enrichments []enrichment.Enrichment) ([]enrichment.Enrichment, error) {
+	ids := make([]string, len(enrichments))
+	for i, e := range enrichments {
+		ids[i] = strconv.FormatInt(e.ID(), 10)
+	}
+
+	existing, err := lookup(ctx, ids)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]enrichment.Enrichment, 0, len(enrichments))
+	for i, e := range enrichments {
+		if _, ok := existing[ids[i]]; !ok {
+			result = append(result, e)
+		}
+	}
+	return result, nil
+}

--- a/application/service/enrichment_test.go
+++ b/application/service/enrichment_test.go
@@ -23,6 +23,9 @@ func (r *recordingBM25Store) Index(_ context.Context, _ search.IndexRequest) err
 func (r *recordingBM25Store) Find(_ context.Context, _ ...repository.Option) ([]search.Result, error) {
 	return nil, nil
 }
+func (r *recordingBM25Store) ExistingIDs(_ context.Context, _ []string) (map[string]struct{}, error) {
+	return map[string]struct{}{}, nil
+}
 func (r *recordingBM25Store) DeleteBy(_ context.Context, opts ...repository.Option) error {
 	r.deleteCalled = true
 	r.deleteOpts = opts

--- a/application/service/search_test.go
+++ b/application/service/search_test.go
@@ -71,6 +71,9 @@ func (f fakeBM25Store) Find(_ context.Context, opts ...repository.Option) ([]sea
 	query, _ := search.QueryFrom(q)
 	return f.resultsByKeyword[query], nil
 }
+func (f fakeBM25Store) ExistingIDs(_ context.Context, _ []string) (map[string]struct{}, error) {
+	return map[string]struct{}{}, nil
+}
 func (f fakeBM25Store) DeleteBy(_ context.Context, _ ...repository.Option) error { return nil }
 
 // seedEnrichments creates enrichments in the real store and returns them in insertion order.

--- a/domain/search/bm25.go
+++ b/domain/search/bm25.go
@@ -15,6 +15,10 @@ type BM25Store interface {
 	// Query text must be passed via WithQuery.
 	Find(ctx context.Context, options ...repository.Option) ([]Result, error)
 
+	// ExistingIDs returns the subset of ids whose snippet IDs already
+	// have BM25 entries in the store.
+	ExistingIDs(ctx context.Context, ids []string) (map[string]struct{}, error)
+
 	// DeleteBy removes documents matching the given options.
 	DeleteBy(ctx context.Context, options ...repository.Option) error
 }

--- a/domain/service/bm25.go
+++ b/domain/service/bm25.go
@@ -70,6 +70,12 @@ func (s *BM25) Find(ctx context.Context, query string, options ...repository.Opt
 	return s.store.Find(ctx, combined...)
 }
 
+// ExistingIDs returns the subset of ids whose snippet IDs already have
+// BM25 entries in the underlying store.
+func (s *BM25) ExistingIDs(ctx context.Context, ids []string) (map[string]struct{}, error) {
+	return s.store.ExistingIDs(ctx, ids)
+}
+
 // DeleteBy removes documents matching the given options.
 func (s *BM25) DeleteBy(ctx context.Context, options ...repository.Option) error {
 	return s.store.DeleteBy(ctx, options...)

--- a/infrastructure/persistence/bm25_store_sqlite.go
+++ b/infrastructure/persistence/bm25_store_sqlite.go
@@ -74,7 +74,9 @@ func (s *SQLiteBM25Store) createTable(ctx context.Context) error {
 	return nil
 }
 
-func (s *SQLiteBM25Store) existingIDs(ctx context.Context, ids []string) (map[string]struct{}, error) {
+// ExistingIDs returns the subset of ids whose snippet IDs already have
+// BM25 entries in the store.
+func (s *SQLiteBM25Store) ExistingIDs(ctx context.Context, ids []string) (map[string]struct{}, error) {
 	if len(ids) == 0 {
 		return map[string]struct{}{}, nil
 	}
@@ -115,7 +117,7 @@ func (s *SQLiteBM25Store) Index(ctx context.Context, request search.IndexRequest
 		ids[i] = doc.SnippetID()
 	}
 
-	existing, err := s.existingIDs(ctx, ids)
+	existing, err := s.ExistingIDs(ctx, ids)
 	if err != nil {
 		return err
 	}

--- a/infrastructure/persistence/bm25_store_vectorchord.go
+++ b/infrastructure/persistence/bm25_store_vectorchord.go
@@ -141,7 +141,10 @@ func (s *VectorChordBM25Store) createTables(ctx context.Context) error {
 	return nil
 }
 
-func (s *VectorChordBM25Store) existingIDs(ctx context.Context, ids []string) (map[string]struct{}, error) {
+// ExistingIDs returns the subset of ids whose snippet IDs already have
+// BM25 entries in the store. Lookups are chunked so the IN-clause bind
+// parameters stay within the PostgreSQL 65535 limit.
+func (s *VectorChordBM25Store) ExistingIDs(ctx context.Context, ids []string) (map[string]struct{}, error) {
 	if len(ids) == 0 {
 		return map[string]struct{}{}, nil
 	}
@@ -209,7 +212,7 @@ func (s *VectorChordBM25Store) Index(ctx context.Context, request search.IndexRe
 		ids[i] = doc.SnippetID()
 	}
 
-	existing, err := s.existingIDs(ctx, ids)
+	existing, err := s.ExistingIDs(ctx, ids)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

Implements deduplication logic in the CreateBM25Index handler to prevent re-indexing enrichments that already have BM25 entries in the search store. This fixes the issue where periodic sync cycles would redundantly re-index stable commits.

## Changes

### Fix: BM25 Dedupe Logic
- **Interface**: Added `ExistingIDs` method to `BM25Store` interface for checking which snippet IDs already have indexed entries
- **Implementations**: 
  - SQLiteBM25Store: Simple direct query against FTS5 table
  - VectorChordBM25Store: Chunked lookup (1000 IDs per batch) to stay within PostgreSQL's 65535 bind parameter limit
- **Handler**: Modified CreateBM25Index to filter out enrichments that already have BM25 entries, emitting Skip state when nothing new to index
- **Tests**: Added comprehensive test coverage for both scenarios (all already indexed, and partial new enrichments)

### Refactor: Shared Dedup Helper
Extracted `filterNewEnrichments` helper function in `application/handler/indexing/filter_new.go` shared by both CreateBM25Index and CreateCodeEmbeddings handlers. This removes 44 lines of duplicate iteration logic and provides a single place to fix dedup behavior in the future.

## Testing

- All unit tests pass (31 packages ok)
- Manual end-to-end testing verified the fix: periodic sync now correctly emits `state=skipped` on subsequent cycles for stable commits
- Live verification against real VectorChord PostgreSQL: 
  - BM25 Index/Find/DeleteBy lifecycle ✓
  - ExistingIDs dedupe with chunked lookups (>1000 IDs) ✓
- Behavior now matches sibling handlers like `create_code_embeddings`

Resolves #555