### PR TITLE
fix: surface PDF extraction failures instead of continuing silently

### DIFF
--- a/application/handler/indexing/chunk_files.go
+++ b/application/handler/indexing/chunk_files.go
@@ -164,9 +164,9 @@ func (h *ChunkFiles) Execute(ctx context.Context, payload map[string]any) error 
 			}
 
 			// Try per-page extraction for page tracking.
+			var perPageErr error
 			if h.textRenderers != nil {
 				if renderer, ok := h.textRenderers.For(ext); ok {
-					var perPageErr error
 					text, pageBoundaries, perPageErr = extractPerPage(renderer, diskPath)
 					if perPageErr != nil {
 						h.logger.Warn().Str("path", f.Path()).Str("error", perPageErr.Error()).Msg("per-page extraction failed, falling back")
@@ -178,13 +178,17 @@ func (h *ChunkFiles) Execute(ctx context.Context, payload map[string]any) error 
 
 			// Fall back to whole-document extraction.
 			if text == "" {
-				var extractErr error
-				text, extractErr = h.documentText.Text(diskPath)
+				fallbackText, extractErr := h.documentText.Text(diskPath)
 				if extractErr != nil {
-					h.logger.Warn().Str("path", f.Path()).Str("error", extractErr.Error()).Msg("failed to extract document text")
-					processed++
-					continue
+					// Both per-page and fallback failed — surface the failure rather than
+					// continue silently. Otherwise indexing reports success while no chunks
+					// are written, leaving search hits with empty content (issue #553).
+					if perPageErr != nil {
+						return fmt.Errorf("extract document text from %s: per-page: %v: fallback: %w", f.Path(), perPageErr, extractErr)
+					}
+					return fmt.Errorf("extract document text from %s: %w", f.Path(), extractErr)
 				}
+				text = fallbackText
 			}
 		} else {
 			content, readErr := h.fileContent.FileContent(ctx, clonedPath, cp.CommitSHA(), relPath)

--- a/application/handler/indexing/chunk_files_test.go
+++ b/application/handler/indexing/chunk_files_test.go
@@ -745,6 +745,17 @@ func (f *fakeDocumentText) Text(path string) (string, error) {
 	return text, nil
 }
 
+// fakeFailingRenderer is an extraction.TextRenderer whose PageCount and Render
+// always return the configured error — used to model PDF parsers that bail at
+// the cross-reference / content-stream layer.
+type fakeFailingRenderer struct {
+	err error
+}
+
+func (f *fakeFailingRenderer) PageCount(_ string) (int, error)        { return 0, f.err }
+func (f *fakeFailingRenderer) Render(_ string, _ int) (string, error) { return "", f.err }
+func (f *fakeFailingRenderer) Close() error                           { return nil }
+
 func TestChunkFiles_ExtractsDocumentFiles(t *testing.T) {
 	ctx := context.Background()
 	logger := zerolog.New(os.Stdout).Level(zerolog.ErrorLevel)
@@ -880,7 +891,7 @@ func TestChunkFiles_SkipsDocumentsWhenExtractorNil(t *testing.T) {
 	assert.Empty(t, chunks, "document files should be skipped when extractor is nil")
 }
 
-func TestChunkFiles_ContinuesOnDocumentExtractionError(t *testing.T) {
+func TestChunkFiles_ReturnsErrorWhenDocumentExtractionFails(t *testing.T) {
 	ctx := context.Background()
 	logger := zerolog.New(os.Stdout).Level(zerolog.ErrorLevel)
 	db := testdb.New(t)
@@ -905,24 +916,15 @@ func TestChunkFiles_ContinuesOnDocumentExtractionError(t *testing.T) {
 	savedRepo, err := repoStore.Save(ctx, repo)
 	require.NoError(t, err)
 
-	// A PDF that will fail extraction, and a Go file that should succeed.
-	f1 := repository.NewFileWithDetails(commitSHA, "bad.pdf", "aaa", "application/pdf", ".pdf", 5000)
-	_, err = fileStore.Save(ctx, f1)
-	require.NoError(t, err)
-	f2 := repository.NewFileWithDetails(commitSHA, "good.go", "bbb", "text/x-go", ".go", 100)
-	_, err = fileStore.Save(ctx, f2)
+	f := repository.NewFileWithDetails(commitSHA, "bad.pdf", "aaa", "application/pdf", ".pdf", 5000)
+	_, err = fileStore.Save(ctx, f)
 	require.NoError(t, err)
 
-	goodContent := make([]byte, 100)
-	for i := range goodContent {
-		goodContent[i] = 'G'
-	}
-
-	docText := &fakeDocumentText{err: fmt.Errorf("corrupt PDF")}
+	docText := &fakeDocumentText{err: fmt.Errorf("invalid xref subsection header")}
 
 	h := NewChunkFiles(
 		repoStore, enrichmentStore, associationStore, lineRangeStore, fileStore,
-		&fakeGitAdapter{files: map[string][]byte{"good.go": goodContent}}, docText, extraction.NewExtractors(), nil,
+		&fakeGitAdapter{}, docText, extraction.NewExtractors(), nil,
 		chunking.ChunkParams{Size: 100, Overlap: 0, MinSize: 1},
 		&fakeTrackerFactory{},
 		logger,
@@ -934,7 +936,9 @@ func TestChunkFiles_ContinuesOnDocumentExtractionError(t *testing.T) {
 	}
 
 	err = h.Execute(ctx, payload)
-	require.NoError(t, err)
+	require.Error(t, err, "Execute must surface a document extraction failure rather than continue silently")
+	assert.Contains(t, err.Error(), "bad.pdf", "error should identify the failing file")
+	assert.Contains(t, err.Error(), "invalid xref subsection header", "error should wrap the underlying parser error")
 
 	chunks, err := enrichmentStore.Find(ctx,
 		enrichment.WithCommitSHA(commitSHA),
@@ -942,7 +946,60 @@ func TestChunkFiles_ContinuesOnDocumentExtractionError(t *testing.T) {
 		enrichment.WithSubtype(enrichment.SubtypeChunk),
 	)
 	require.NoError(t, err)
-	assert.Len(t, chunks, 1, "should create chunks for the Go file despite PDF extraction error")
+	assert.Empty(t, chunks, "no chunks should be created when extraction fails")
+}
+
+func TestChunkFiles_ReturnsErrorWhenPerPageExtractionFails(t *testing.T) {
+	ctx := context.Background()
+	logger := zerolog.New(os.Stdout).Level(zerolog.ErrorLevel)
+	db := testdb.New(t)
+
+	enrichmentStore := persistence.NewEnrichmentStore(db)
+	associationStore := persistence.NewAssociationStore(db)
+	lineRangeStore := persistence.NewSourceLocationStore(db)
+	repoStore := persistence.NewRepositoryStore(db)
+	fileStore := persistence.NewFileStore(db)
+
+	commitSHA := "perpageerr111"
+	tmpDir := t.TempDir()
+
+	cc, err := repository.NewChunkingConfig(100, 0, 1)
+	require.NoError(t, err)
+	repo, err := repository.NewRepository("https://github.com/test/repo")
+	require.NoError(t, err)
+	repo = repo.
+		WithWorkingCopy(repository.NewWorkingCopy(tmpDir, "https://github.com/test/repo")).
+		WithTrackingConfig(repository.NewTrackingConfig("main", "", "")).
+		WithChunkingConfig(cc)
+	savedRepo, err := repoStore.Save(ctx, repo)
+	require.NoError(t, err)
+
+	f := repository.NewFileWithDetails(commitSHA, "broken.pdf", "aaa", "application/pdf", ".pdf", 5000)
+	_, err = fileStore.Save(ctx, f)
+	require.NoError(t, err)
+
+	// Both per-page and whole-document extractors fail with the same xref error
+	// — this is the real-world case from issue #553.
+	registry := extraction.NewTextRendererRegistry()
+	registry.Register(".pdf", &fakeFailingRenderer{err: fmt.Errorf("invalid xref subsection header")})
+	docText := &fakeDocumentText{err: fmt.Errorf("invalid xref subsection header")}
+
+	h := NewChunkFiles(
+		repoStore, enrichmentStore, associationStore, lineRangeStore, fileStore,
+		&fakeGitAdapter{}, docText, extraction.NewExtractors(), registry,
+		chunking.ChunkParams{Size: 100, Overlap: 0, MinSize: 1},
+		&fakeTrackerFactory{},
+		logger,
+	)
+
+	payload := map[string]any{
+		"repository_id": savedRepo.ID(),
+		"commit_sha":    commitSHA,
+	}
+
+	err = h.Execute(ctx, payload)
+	require.Error(t, err, "Execute must surface a document extraction failure rather than continue silently")
+	assert.Contains(t, err.Error(), "broken.pdf", "error should identify the failing file")
 }
 
 func TestChunkFiles_ParsesCSVFiles(t *testing.T) {


### PR DESCRIPTION
## Summary

When both per-page and whole-document PDF extraction fail, indexing now surfaces the failure instead of silently continuing. This prevents the regression where indexing reports completion while producing zero chunks, leaving search hits with empty Content.

Fixes #553: unparseable PDFs (e.g. arxiv 2604.25927v1.pdf with xref parse errors) would be indexed successfully but yield search hits with no text, making it appear the LLM was ignoring the knowledge.

## Changes

- Move `perPageErr` declaration outside the if block so both extraction paths' errors can be chained
- Return wrapped error when fallback extraction fails instead of logging and continuing
- Update existing test that codified the old behavior to verify the new behavior
- Add `fakeFailingRenderer` test helper for modeling unparseable PDFs

## Testing

- Unit tests verify that Execute returns an error when both per-page and fallback extraction fail
- Manually verified end-to-end against the arxiv PDF from the issue: Execute returns a clear error chain and creates zero chunks
- Full `make check` passes (no regressions)