### PR TITLE
docs: add missing service package import to Go library example

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,10 @@ The enrichment tools (`architecture_docs`, `api_docs`, `database_schema`, `cookb
 Kodit can be embedded directly as a Go library. This is how [Helix](https://helix.ml) integrates Kodit into its platform.
 
 ```go
-import "github.com/helixml/kodit"
+import (
+    "github.com/helixml/kodit"
+    "github.com/helixml/kodit/application/service"
+)
 
 client, err := kodit.New(
     kodit.WithSQLite(".kodit/data.db"),


### PR DESCRIPTION
## Summary

- The Go library example in README.md used `service.RepositoryAddParams` and `service.WithLimit` but only imported `github.com/helixml/kodit`
- The `service` package (`github.com/helixml/kodit/application/service`) is not re-exported from the root package, so the example would not compile
- Expanded the single import to an import group that includes the service package

## Tasks completed

- T21: Add missing service package import to Go library example

## Test plan

- [ ] verify.sh passes (confirmed locally)
- [ ] Example code compiles with both imports present