### PR TITLE
docs: fix authentication header from Authorization: Bearer to X-API-KEY

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,10 @@ The enrichment tools (`architecture_docs`, `api_docs`, `database_schema`, `cookb
 Kodit can be embedded directly as a Go library. This is how [Helix](https://helix.ml) integrates Kodit into its platform.
 
 ```go
-import "github.com/helixml/kodit"
+import (
+    "github.com/helixml/kodit"
+    "github.com/helixml/kodit/application/service"
+)
 
 client, err := kodit.New(
     kodit.WithSQLite(".kodit/data.db"),

--- a/README.md
+++ b/README.md
@@ -403,7 +403,7 @@ spec:
 
 ### Authentication
 
-Set the `API_KEYS` environment variable to a comma-separated list of keys. Write endpoints (creating repositories, triggering syncs) require a valid key in the `Authorization: Bearer <key>` header. Search endpoints are open by default.
+Set the `API_KEYS` environment variable to a comma-separated list of keys. Write endpoints (creating repositories, triggering syncs) require a valid key in the `X-API-KEY: <key>` header. Search endpoints are open by default.
 
 ## Configuration Reference
 
@@ -552,7 +552,7 @@ Key endpoints:
 | `GET` | `/api/v1/search/grep` | Regex pattern search |
 | `GET` | `/api/v1/search/ls` | List files by glob |
 
-All write endpoints require an `Authorization: Bearer <key>` header when `API_KEYS` is set.
+All write endpoints require an `X-API-KEY: <key>` header when `API_KEYS` is set.
 
 ## How Indexing Works
 


### PR DESCRIPTION
## Summary

- Corrected the authentication header in two places in the README
- The middleware reads `X-API-KEY` (not `Authorization: Bearer <key>`) per `infrastructure/api/middleware/auth.go` line 59
- Both the Authentication section and the REST API section referenced the wrong header format

## Tasks completed

- T22: Fix authentication header in README from `Authorization: Bearer` to `X-API-KEY`