### PR TITLE
perf: add composite indexes on tasks table

### DIFF
--- a/infrastructure/persistence/models.go
+++ b/infrastructure/persistence/models.go
@@ -171,10 +171,10 @@ func (EmbeddingModel) TableName() string {
 type TaskModel struct {
 	ID        int64           `gorm:"column:id;primaryKey;autoIncrement"`
 	DedupKey  string          `gorm:"column:dedup_key;type:varchar(255);uniqueIndex;not null"`
-	Type      string          `gorm:"column:type;type:varchar(255);index;not null"`
+	Type      string          `gorm:"column:type;type:varchar(255);index;not null;index:idx_tasks_type_priority_created,priority:1"`
 	Payload   json.RawMessage `gorm:"column:payload;type:jsonb"`
-	Priority  int             `gorm:"column:priority;not null"`
-	CreatedAt time.Time       `gorm:"column:created_at;autoCreateTime"`
+	Priority  int             `gorm:"column:priority;not null;index:idx_tasks_priority_created,priority:1,sort:desc;index:idx_tasks_type_priority_created,priority:2,sort:desc"`
+	CreatedAt time.Time       `gorm:"column:created_at;autoCreateTime;index:idx_tasks_priority_created,priority:2,sort:asc;index:idx_tasks_type_priority_created,priority:3,sort:asc"`
 	UpdatedAt time.Time       `gorm:"column:updated_at;autoUpdateTime"`
 }
 


### PR DESCRIPTION
## Summary
The `Dequeue` and `DequeueByOperation` queries order by `priority DESC, created_at ASC` but the `tasks` table had no matching index, causing a full table scan + sort on every dequeue call.

## Changes
- Added composite index `idx_tasks_priority_created` (priority DESC, created_at ASC) for `Dequeue`
- Added composite index `idx_tasks_type_priority_created` (type, priority DESC, created_at ASC) for `DequeueByOperation`
- Both indexes are defined via GORM struct tags on `TaskModel` and will be created automatically by AutoMigrate

## Testing
- `golangci-lint` passes clean (0 issues)
- Indexes will be created on next application startup via GORM AutoMigrate
- Verify with `EXPLAIN ANALYZE` after deployment that both queries use index scans

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01km00txafwfd22yqdzvkcd5ar/tasks/spt_01kvsmkcmyq2jy0m2426aw6rt9)

📋 Spec:
- [Requirements](https://github.com/helixml/kodit/blob/helix-specs/design/tasks/002164_can-you-check-if-there/requirements.md)
- [Design](https://github.com/helixml/kodit/blob/helix-specs/design/tasks/002164_can-you-check-if-there/design.md)
- [Tasks](https://github.com/helixml/kodit/blob/helix-specs/design/tasks/002164_can-you-check-if-there/tasks.md)

🚀 Built with [Helix](https://helix.ml)